### PR TITLE
feat: versioned learning DB datasets via GitHub Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ site/
 
 # uv lock file
 uv.lock
+
+# Dataset binary files (distributed via GitHub Releases, not git)
+datasets/*/memory_db/
+*.tar.gz

--- a/datasets/5000t-seed42-v1.0/baseline_results.json
+++ b/datasets/5000t-seed42-v1.0/baseline_results.json
@@ -1,0 +1,193 @@
+{
+  "overall_score": 0.9047,
+  "num_turns": 5000,
+  "num_questions": 100,
+  "total_facts_delivered": 762,
+  "questioning_time_s": 1082.14,
+  "grading_time_s": 122.28,
+  "category_breakdown": [
+    {
+      "category": "adversarial_distractor",
+      "num_questions": 12,
+      "avg_score": 0.8958,
+      "min_score": 0.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.9167,
+        "specificity": 0.875,
+        "temporal_awareness": 0.5
+      }
+    },
+    {
+      "category": "cross_reference",
+      "num_questions": 5,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "distractor_resistance",
+      "num_questions": 3,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "confidence_calibration": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "incident_tracking",
+      "num_questions": 4,
+      "avg_score": 0.8375,
+      "min_score": 0.65,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.9375,
+        "temporal_awareness": 0.6,
+        "specificity": 0.875
+      }
+    },
+    {
+      "category": "infrastructure_knowledge",
+      "num_questions": 4,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "meta_memory",
+      "num_questions": 5,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "multi_hop_reasoning",
+      "num_questions": 12,
+      "avg_score": 0.9246,
+      "min_score": 0.7143,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.9221,
+        "specificity": 0.9221,
+        "temporal_awareness": 1.0
+      }
+    },
+    {
+      "category": "needle_in_haystack",
+      "num_questions": 8,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "numerical_precision",
+      "num_questions": 6,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "numerical_reasoning",
+      "num_questions": 7,
+      "avg_score": 0.869,
+      "min_score": 0.5,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.869,
+        "specificity": 0.869
+      }
+    },
+    {
+      "category": "problem_solving",
+      "num_questions": 4,
+      "avg_score": 1.0,
+      "min_score": 1.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "security_log_analysis",
+      "num_questions": 5,
+      "avg_score": 0.9833,
+      "min_score": 0.9167,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.975,
+        "specificity": 0.975,
+        "temporal_awareness": 1.0
+      }
+    },
+    {
+      "category": "source_attribution",
+      "num_questions": 5,
+      "avg_score": 0.995,
+      "min_score": 0.975,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 1.0,
+        "source_attribution": 0.99,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "temporal_evolution",
+      "num_questions": 10,
+      "avg_score": 0.8967,
+      "min_score": 0.5,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.8,
+        "temporal_awareness": 0.99,
+        "specificity": 1.0
+      }
+    },
+    {
+      "category": "temporal_trap",
+      "num_questions": 10,
+      "avg_score": 0.5333,
+      "min_score": 0.0,
+      "max_score": 1.0,
+      "dimension_averages": {
+        "factual_accuracy": 0.2,
+        "temporal_awareness": 0.9,
+        "specificity": 0.0
+      }
+    }
+  ],
+  "memory_stats": {
+    "sensory": 0,
+    "working": 0,
+    "episodic": 5000,
+    "semantic": 10854,
+    "procedural": 0,
+    "prospective": 0,
+    "total": 15854,
+    "total_experiences": 15854
+  }
+}

--- a/datasets/5000t-seed42-v1.0/metadata.json
+++ b/datasets/5000t-seed42-v1.0/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "5000t-seed42-v1.0",
+  "version": "1.0",
+  "turns": 5000,
+  "seed": 42,
+  "facts_delivered": 762,
+  "baseline_score": 0.9047,
+  "code_version": "ff20586",
+  "date": "2026-02-24",
+  "agent_type": "LearningAgent (CognitiveMemory)",
+  "num_questions_tested": 100,
+  "num_categories": 15,
+  "memory_stats": {
+    "episodic": 5000,
+    "semantic": 10854,
+    "total": 15854
+  },
+  "description": "Pre-built memory database from 5000-turn learning phase with seed 42. Contains 762 facts across 12 information blocks and 15 question categories. Baseline evaluation score: 90.47%."
+}

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,96 @@
+# Pre-built Learning DB Datasets
+
+Pre-built memory databases for the long-horizon evaluation, distributed via GitHub Releases.
+
+## Why?
+
+The 5000-turn learning phase takes **4+ hours** and requires 10,000+ LLM API calls.
+These pre-built datasets let you skip learning and jump straight to evaluation.
+
+## Available Datasets
+
+| Name | Turns | Seed | Facts | Baseline Score | Date |
+|------|-------|------|-------|---------------|------|
+| `5000t-seed42-v1.0` | 5,000 | 42 | 762 | 90.47% | 2026-02-24 |
+
+## Quick Start
+
+```bash
+# Download a dataset
+amplihack-eval download-dataset 5000t-seed42-v1.0
+
+# Run evaluation using the pre-built DB (skip 4+ hour learning phase)
+amplihack-eval run \
+  --adapter learning-agent \
+  --skip-learning \
+  --load-db datasets/5000t-seed42-v1.0/memory_db \
+  --turns 5000 \
+  --questions 100
+```
+
+## Programmatic Download
+
+```python
+from amplihack_eval.datasets.download import download_dataset, list_datasets
+
+# List available datasets
+datasets = list_datasets()
+
+# Download a specific dataset
+path = download_dataset("5000t-seed42-v1.0")
+print(f"Downloaded to: {path}")
+```
+
+## Dataset Structure
+
+Each dataset directory contains:
+
+```
+5000t-seed42-v1.0/
+├── metadata.json          # Dataset configuration and provenance
+├── baseline_results.json  # Evaluation scores at time of creation
+└── memory_db/             # Kuzu graph database (the actual pre-built DB)
+```
+
+### metadata.json Schema
+
+```json
+{
+  "name": "5000t-seed42-v1.0",
+  "version": "1.0",
+  "turns": 5000,
+  "seed": 42,
+  "facts_delivered": 762,
+  "baseline_score": 0.9047,
+  "code_version": "ff20586",
+  "date": "2026-02-24",
+  "agent_type": "LearningAgent (CognitiveMemory)",
+  "num_questions_tested": 100,
+  "num_categories": 15,
+  "memory_stats": {
+    "episodic": 5000,
+    "semantic": 10854,
+    "total": 15854
+  }
+}
+```
+
+## Creating New Datasets
+
+After running a long learning phase, package the results:
+
+```bash
+# 1. Run the full learning phase
+amplihack-eval run --adapter learning-agent --turns 5000 --questions 100 \
+  --output-dir /tmp/my-eval
+
+# 2. Package as a dataset (future: automated script)
+# For now, copy memory_db/ and create metadata.json manually
+
+# 3. Create a GitHub release
+tar -czf 5000t-seed42-v1.0.tar.gz -C datasets/ 5000t-seed42-v1.0/
+gh release create dataset-5000t-seed42-v1.0 \
+  --title "5000-Turn Learning DB (seed 42, v1.0)" \
+  --notes "Pre-built memory DB: 5000 turns, 762 facts, 90.47% baseline" \
+  5000t-seed42-v1.0.tar.gz
+```

--- a/src/amplihack_eval/datasets/__init__.py
+++ b/src/amplihack_eval/datasets/__init__.py
@@ -1,0 +1,13 @@
+"""Pre-built learning DB datasets for long-horizon evaluation.
+
+Public API:
+    download_dataset: Download a dataset from GitHub Releases
+    list_datasets: List available datasets from GitHub Releases
+    load_metadata: Load metadata.json from a local dataset
+"""
+
+from __future__ import annotations
+
+from .download import download_dataset, list_datasets, load_metadata
+
+__all__ = ["download_dataset", "list_datasets", "load_metadata"]

--- a/src/amplihack_eval/datasets/download.py
+++ b/src/amplihack_eval/datasets/download.py
@@ -1,0 +1,264 @@
+"""Download pre-built learning DB datasets from GitHub Releases.
+
+Philosophy:
+- Zero external dependencies (uses urllib + tarfile from stdlib)
+- Fail-fast with clear error messages
+- Idempotent: re-downloading an existing dataset is a no-op
+
+Public API:
+    download_dataset: Download and extract a dataset by name
+    list_datasets: List available datasets from GitHub Releases
+    load_metadata: Load metadata.json from a local dataset directory
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+GITHUB_REPO = "rysweet/amplihack-agent-eval"
+GITHUB_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases"
+DATASETS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "datasets"
+
+
+def _get_datasets_dir() -> Path:
+    """Get the datasets directory, creating it if needed."""
+    DATASETS_DIR.mkdir(parents=True, exist_ok=True)
+    return DATASETS_DIR
+
+
+def list_datasets(include_remote: bool = True) -> list[dict[str, Any]]:
+    """List available datasets (local and optionally remote).
+
+    Args:
+        include_remote: If True, also check GitHub Releases for available datasets.
+
+    Returns:
+        List of dataset info dicts with keys: name, local, version, etc.
+    """
+    datasets: list[dict[str, Any]] = []
+
+    # Local datasets
+    ds_dir = _get_datasets_dir()
+    for entry in sorted(ds_dir.iterdir()):
+        if entry.is_dir() and (entry / "metadata.json").exists():
+            meta = load_metadata(entry)
+            meta["local"] = True
+            meta["path"] = str(entry)
+            datasets.append(meta)
+
+    if not include_remote:
+        return datasets
+
+    # Remote datasets from GitHub Releases
+    local_names = {d["name"] for d in datasets}
+    try:
+        remote = _fetch_releases()
+        for release in remote:
+            tag = release.get("tag_name", "")
+            if not tag.startswith("dataset-"):
+                continue
+            name = tag.removeprefix("dataset-")
+            if name not in local_names:
+                datasets.append({
+                    "name": name,
+                    "local": False,
+                    "tag": tag,
+                    "url": release.get("html_url", ""),
+                    "published": release.get("published_at", ""),
+                })
+    except Exception as e:
+        logger.warning("Could not fetch remote datasets: %s", e)
+
+    return datasets
+
+
+def download_dataset(
+    name: str,
+    output_dir: Path | None = None,
+    force: bool = False,
+) -> Path:
+    """Download and extract a dataset from GitHub Releases.
+
+    Args:
+        name: Dataset name (e.g., "5000t-seed42-v1.0")
+        output_dir: Where to extract (default: datasets/ in repo root)
+        force: Re-download even if already exists locally
+
+    Returns:
+        Path to the extracted dataset directory
+
+    Raises:
+        RuntimeError: If dataset not found or download fails
+    """
+    dest_dir = (output_dir or _get_datasets_dir()) / name
+
+    if dest_dir.exists() and not force:
+        logger.info("Dataset already exists at %s (use force=True to re-download)", dest_dir)
+        return dest_dir
+
+    tag = f"dataset-{name}"
+
+    # Try gh CLI first (handles authentication automatically)
+    if _download_with_gh(tag, name, dest_dir):
+        return dest_dir
+
+    # Fallback to urllib (works for public repos without auth)
+    _download_with_urllib(tag, name, dest_dir)
+    return dest_dir
+
+
+def _download_with_gh(tag: str, name: str, dest_dir: Path) -> bool:
+    """Download using gh CLI (preferred, handles auth)."""
+    if not shutil.which("gh"):
+        return False
+
+    tarball = f"{name}.tar.gz"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        try:
+            result = subprocess.run(
+                ["gh", "release", "download", tag,
+                 "--repo", GITHUB_REPO,
+                 "--pattern", tarball,
+                 "--dir", str(tmp_path)],
+                capture_output=True, text=True, timeout=120,
+            )
+            if result.returncode != 0:
+                logger.debug("gh download failed: %s", result.stderr)
+                return False
+
+            tarball_path = tmp_path / tarball
+            if not tarball_path.exists():
+                return False
+
+            _extract_tarball(tarball_path, dest_dir)
+            logger.info("Downloaded %s via gh CLI -> %s", name, dest_dir)
+            return True
+
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.debug("gh download error: %s", e)
+            return False
+
+
+def _download_with_urllib(tag: str, name: str, dest_dir: Path) -> None:
+    """Download using urllib (fallback for public repos)."""
+    tarball = f"{name}.tar.gz"
+
+    # Find the asset URL from the release
+    try:
+        releases = _fetch_releases()
+    except Exception as e:
+        raise RuntimeError(f"Cannot fetch releases: {e}") from e
+
+    asset_url = None
+    for release in releases:
+        if release.get("tag_name") != tag:
+            continue
+        for asset in release.get("assets", []):
+            if asset.get("name") == tarball:
+                asset_url = asset.get("browser_download_url")
+                break
+        break
+
+    if not asset_url:
+        raise RuntimeError(
+            f"Dataset '{name}' not found in GitHub Releases.\n"
+            f"Expected release tag: {tag}\n"
+            f"Expected asset: {tarball}\n"
+            f"Check available releases: https://github.com/{GITHUB_REPO}/releases"
+        )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp) / tarball
+        logger.info("Downloading %s ...", asset_url)
+
+        try:
+            req = Request(asset_url, headers={"Accept": "application/octet-stream"})
+            with urlopen(req, timeout=300) as resp, open(tmp_path, "wb") as f:
+                while True:
+                    chunk = resp.read(8192)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        except URLError as e:
+            raise RuntimeError(f"Download failed: {e}") from e
+
+        _extract_tarball(tmp_path, dest_dir)
+        logger.info("Downloaded %s via urllib -> %s", name, dest_dir)
+
+
+def _extract_tarball(tarball_path: Path, dest_dir: Path) -> None:
+    """Extract a tarball to the destination directory."""
+    dest_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    # Clean existing if re-downloading
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_extract = Path(tmp) / "extract"
+        tmp_extract.mkdir()
+
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            # Security: check for path traversal
+            for member in tar.getmembers():
+                if member.name.startswith("/") or ".." in member.name:
+                    raise RuntimeError(f"Unsafe path in tarball: {member.name}")
+            # Use filter='data' on Python 3.12+ to avoid deprecation warning
+            extract_kwargs: dict[str, Any] = {"path": tmp_extract}
+            if hasattr(tarfile, "data_filter"):
+                extract_kwargs["filter"] = "data"
+            tar.extractall(**extract_kwargs)
+
+        # The tarball may contain a top-level directory or files directly
+        extracted = list(tmp_extract.iterdir())
+        if len(extracted) == 1 and extracted[0].is_dir():
+            # Single top-level directory - move it
+            shutil.move(str(extracted[0]), str(dest_dir))
+        else:
+            # Files directly - wrap in dest_dir
+            shutil.move(str(tmp_extract), str(dest_dir))
+
+
+def _fetch_releases() -> list[dict[str, Any]]:
+    """Fetch release list from GitHub API."""
+    req = Request(GITHUB_API, headers={"Accept": "application/vnd.github.v3+json"})
+    try:
+        with urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except URLError as e:
+        raise RuntimeError(f"Cannot reach GitHub API: {e}") from e
+
+
+def load_metadata(dataset_path: Path) -> dict[str, Any]:
+    """Load metadata.json from a dataset directory.
+
+    Args:
+        dataset_path: Path to the dataset directory
+
+    Returns:
+        Metadata dict
+
+    Raises:
+        FileNotFoundError: If metadata.json does not exist
+    """
+    meta_path = dataset_path / "metadata.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(f"No metadata.json in {dataset_path}")
+
+    with open(meta_path) as f:
+        return json.load(f)
+
+
+__all__ = ["download_dataset", "list_datasets", "load_metadata"]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,207 @@
+"""Tests for datasets download and management.
+
+Tests the download helper, metadata loading, and CLI integration.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amplihack_eval.datasets.download import (
+    _extract_tarball,
+    _get_datasets_dir,
+    list_datasets,
+    load_metadata,
+)
+
+
+class TestLoadMetadata:
+    """Test metadata loading from dataset directories."""
+
+    def test_load_valid_metadata(self, tmp_path: Path):
+        meta = {"name": "test-v1.0", "turns": 100, "seed": 42}
+        (tmp_path / "metadata.json").write_text(json.dumps(meta))
+
+        result = load_metadata(tmp_path)
+        assert result["name"] == "test-v1.0"
+        assert result["turns"] == 100
+        assert result["seed"] == 42
+
+    def test_load_missing_metadata(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_metadata(tmp_path)
+
+
+class TestListDatasets:
+    """Test listing local and remote datasets."""
+
+    def test_list_local_datasets(self, tmp_path: Path):
+        # Create a fake local dataset
+        ds_dir = tmp_path / "test-v1.0"
+        ds_dir.mkdir()
+        meta = {"name": "test-v1.0", "turns": 100, "baseline_score": 0.85}
+        (ds_dir / "metadata.json").write_text(json.dumps(meta))
+
+        with patch("amplihack_eval.datasets.download._get_datasets_dir", return_value=tmp_path):
+            datasets = list_datasets(include_remote=False)
+
+        assert len(datasets) == 1
+        assert datasets[0]["name"] == "test-v1.0"
+        assert datasets[0]["local"] is True
+
+    def test_list_empty_directory(self, tmp_path: Path):
+        with patch("amplihack_eval.datasets.download._get_datasets_dir", return_value=tmp_path):
+            datasets = list_datasets(include_remote=False)
+
+        assert datasets == []
+
+
+class TestExtractTarball:
+    """Test tarball extraction with safety checks."""
+
+    def test_extract_single_directory(self, tmp_path: Path):
+        # Create a tarball with a single top-level directory
+        src = tmp_path / "src"
+        ds = src / "my-dataset"
+        ds.mkdir(parents=True)
+        (ds / "metadata.json").write_text('{"name": "my-dataset"}')
+        (ds / "data.txt").write_text("test data")
+
+        tarball = tmp_path / "test.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            tar.add(ds, arcname="my-dataset")
+
+        dest = tmp_path / "output" / "my-dataset"
+        _extract_tarball(tarball, dest)
+
+        assert dest.exists()
+        assert (dest / "metadata.json").exists()
+        assert (dest / "data.txt").read_text() == "test data"
+
+    def test_extract_rejects_path_traversal(self, tmp_path: Path):
+        # Create a tarball with path traversal
+        tarball = tmp_path / "evil.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            # Add a file with path traversal in name
+            import io
+
+            info = tarfile.TarInfo(name="../../../etc/passwd")
+            info.size = 4
+            tar.addfile(info, io.BytesIO(b"evil"))
+
+        dest = tmp_path / "output"
+        with pytest.raises(RuntimeError, match="Unsafe path"):
+            _extract_tarball(tarball, dest)
+
+
+class TestGetDatasetsDir:
+    """Test datasets directory resolution."""
+
+    def test_creates_directory(self, tmp_path: Path):
+        with patch("amplihack_eval.datasets.download.DATASETS_DIR", tmp_path / "datasets"):
+            result = _get_datasets_dir()
+            assert result.exists()
+            assert result.is_dir()
+
+
+class TestCLIIntegration:
+    """Test CLI commands for dataset management."""
+
+    def test_list_datasets_command(self):
+        """Verify list-datasets command is registered."""
+        import subprocess
+
+        result = subprocess.run(
+            ["amplihack-eval", "list-datasets", "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "local-only" in result.stdout
+
+    def test_download_dataset_command(self):
+        """Verify download-dataset command is registered."""
+        import subprocess
+
+        result = subprocess.run(
+            ["amplihack-eval", "download-dataset", "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "dataset_name" in result.stdout
+
+    def test_run_skip_learning_flag(self):
+        """Verify --skip-learning flag is registered."""
+        import subprocess
+
+        result = subprocess.run(
+            ["amplihack-eval", "run", "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "--skip-learning" in result.stdout
+        assert "--load-db" in result.stdout
+
+    def test_skip_learning_requires_load_db(self):
+        """--skip-learning without --load-db should error."""
+        import subprocess
+
+        result = subprocess.run(
+            ["amplihack-eval", "run", "--skip-learning"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "--load-db" in result.stderr
+
+
+class TestRunSkipLearning:
+    """Test EvalRunner.run_skip_learning method."""
+
+    def test_method_exists(self):
+        from amplihack_eval.core.runner import EvalRunner
+
+        runner = EvalRunner(num_turns=10, num_questions=2)
+        assert hasattr(runner, "run_skip_learning")
+
+    def test_generates_questions_without_learning(self):
+        """run_skip_learning should generate questions but not feed dialogue."""
+        from amplihack_eval.core.runner import EvalRunner
+
+        runner = EvalRunner(num_turns=10, num_questions=2, seed=42)
+
+        # Mock agent that tracks calls
+        class MockAgent:
+            def __init__(self):
+                self.learn_calls = 0
+                self.answer_calls = 0
+
+            def learn(self, content):
+                self.learn_calls += 1
+
+            def answer(self, question):
+                self.answer_calls += 1
+                from amplihack_eval.adapters.base import AgentResponse
+
+                return AgentResponse(answer="test answer")
+
+            def reset(self):
+                pass
+
+            def close(self):
+                pass
+
+        agent = MockAgent()
+        report = runner.run_skip_learning(agent, load_db_path="/tmp/fake_db")
+
+        # Should NOT have called learn
+        assert agent.learn_calls == 0
+        # Should have called answer for each question
+        assert agent.answer_calls == 2
+        # Learning time should be 0
+        assert report.learning_time_s == 0.0
+        assert report.num_questions == 2


### PR DESCRIPTION
## Summary

- Implement pre-built learning DB dataset distribution via GitHub Releases to skip the 4+ hour learning phase
- Add `download-dataset` and `list-datasets` CLI commands
- Add `--skip-learning` and `--load-db` flags to the `run` command
- Create first dataset release: `5000t-seed42-v1.0` (5000 turns, 762 facts, 90.47% baseline)

## Changes

### New Files
- `datasets/README.md` - Dataset documentation and usage guide
- `datasets/5000t-seed42-v1.0/metadata.json` - First dataset metadata
- `datasets/5000t-seed42-v1.0/baseline_results.json` - Baseline evaluation scores
- `src/amplihack_eval/datasets/__init__.py` - Package init
- `src/amplihack_eval/datasets/download.py` - Download helper (gh CLI + urllib fallback)
- `tests/test_datasets.py` - 13 tests for the datasets module

### Modified Files
- `src/amplihack_eval/cli.py` - New subcommands and flags
- `src/amplihack_eval/core/runner.py` - `run_skip_learning()` method
- `docs/LONG_HORIZON_EVAL.md` - Pre-built datasets documentation section
- `.gitignore` - Exclude binary memory_db/ files and tarballs

### GitHub Release
- Tag: `dataset-5000t-seed42-v1.0`
- Asset: `5000t-seed42-v1.0.tar.gz` (1.3 MB compressed, 22 MB uncompressed)

## Test Plan

- [x] 13 new unit tests pass (metadata loading, tarball extraction, CLI integration, path traversal security)
- [x] 290/291 existing tests pass (1 pre-existing failure unrelated to this PR)
- [x] `amplihack-eval list-datasets` correctly shows local dataset
- [x] `amplihack-eval download-dataset 5000t-seed42-v1.0` downloads from GitHub Release
- [x] `amplihack-eval run --skip-learning --load-db <path>` skips learning phase
- [x] End-to-end: download → extract → load → evaluate runs without errors
- [x] Tarball extraction rejects path traversal attacks

## Known Limitation

The LearningAgent may need a separate fix to properly load an existing Kuzu DB at a given path (currently creates a fresh DB). This is a `amplihack-memory-lib` issue, not a dataset distribution issue.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)