### PR TITLE
fix: include replica count in database dialogue turns (infra_03)

### DIFF
--- a/src/amplihack_eval/data/long_horizon.py
+++ b/src/amplihack_eval/data/long_horizon.py
@@ -2784,15 +2784,22 @@ def generate_dialogue(num_turns: int = 1000, seed: int = 42) -> GroundTruth:
         for db in INFRASTRUCTURE["databases"]:
             if turn_idx >= b_end:
                 break
+            replica_suffix = (
+                f" with {db['replicas']} replicas" if db.get("replicas") else ""
+            )
             content = (
                 f"Infrastructure: Database '{db['name']}' running {db['engine']} "
-                f"at {db['host']}:{db['port']}, size {db['size_gb']}GB."
+                f"at {db['host']}:{db['port']}, size {db['size_gb']}GB{replica_suffix}."
             )
             facts = [
                 {"entity": f"db_{db['name']}", "attribute": "engine", "value": db["engine"]},
                 {"entity": f"db_{db['name']}", "attribute": "host", "value": db["host"]},
                 {"entity": f"db_{db['name']}", "attribute": "size_gb", "value": str(db["size_gb"])},
             ]
+            if db.get("replicas"):
+                facts.append(
+                    {"entity": f"db_{db['name']}", "attribute": "replicas", "value": str(db["replicas"])}
+                )
             for f in facts:
                 ek = f"{f['entity']}.{f['attribute']}"
                 facts_by_entity.setdefault(ek, []).append({"value": f["value"], "turn": turn_idx})


### PR DESCRIPTION
## Summary

- The `replicas` field was defined in `INFRASTRUCTURE['databases']` for `pg-primary` (replicas: 2) but was never included in the generated turn content or facts list
- This caused the learning phase to skip this fact, so the `infra_03` eval question could not match the required keyword `2` (from '2 replicas')
- Discovered during agentic eval investigation (rysweet/amplihack#2690)

## Change

```python
# Before: replica count silently dropped
content = f"... size {db['size_gb']}GB."
facts = [engine, host, size_gb]

# After: replica count included when present
replica_suffix = f" with {db['replicas']} replicas" if db.get("replicas") else ""
content = f"... size {db['size_gb']}GB{replica_suffix}."
facts = [engine, host, size_gb, replicas]  # replicas added conditionally
```

## Test Plan

- [ ] Re-generate a 5000-turn DB and verify infra_03 scores 100% in both single-shot and agentic mode
- [ ] Verify other databases (redis-cache, es-logs) without `replicas` key are unaffected

Related: rysweet/amplihack#2690, rysweet/amplihack#2535

🤖 Generated with [Claude Code](https://claude.com/claude-code)