### PR TITLE
docs(hive): add Azure hive Q&A eval tutorial for query_hive.py

### DIFF
--- a/docs/azure-hive-qa-eval.md
+++ b/docs/azure-hive-qa-eval.md
@@ -71,7 +71,7 @@ python experiments/hive_mind/query_hive.py --run-eval --timeout 15
 ```
 ======================================================================
 LIVE AZURE HIVE Q&A EVAL
-Hive: hive-sb-dj2qo2w7vu5zi / topic: hive-graph
+Hive: hive-sb / topic: hive-graph
 Questions: 15
 Timeout per query: 10s
 ======================================================================
@@ -191,7 +191,7 @@ client.close()
 | Component | Value |
 |---|---|
 | Azure resource group | `hive-mind-rg` |
-| Service Bus namespace | `hive-sb-dj2qo2w7vu5zi` |
+| Service Bus namespace | See `HIVE_CONNECTION_STRING` env var |
 | Topic | `hive-graph` |
 | Eval subscription | `eval-query-agent` |
 | Agent subscriptions | `agent-0` … `agent-19` |


### PR DESCRIPTION
## Summary

- Adds `docs/azure-hive-qa-eval.md`: comprehensive tutorial documenting how to use `query_hive.py` for Q&A evaluation against a live Azure Service Bus hive
- Covers all three modes: `--demo` (local, no Azure), `--seed` (seed facts into live hive), and `--run-eval` (run 15-question Q&A dataset against live hive)
- Documents result interpretation, known limitations (NetworkGraphStore vs CognitiveAdapter routing), and next steps

## Test plan

- [ ] Review `docs/azure-hive-qa-eval.md` for accuracy and completeness
- [ ] Verify the tutorial matches the actual `query_hive.py` CLI flags and behavior
- [ ] Confirm `--demo` mode instructions produce ~80% accuracy as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)