### PR TITLE
docs: update eval instructions for current architecture

### DIFF
--- a/docs/LONG_HORIZON_EVAL.md
+++ b/docs/LONG_HORIZON_EVAL.md
@@ -2,9 +2,15 @@
 
 ## What It Tests
 
-The long-horizon memory evaluation is a stress test for AI agent memory systems. It generates a structured dialogue of up to 5000 turns, feeds each turn to the agent's `learn()` method, then quizzes the agent on details from various points in the conversation. The goal is to measure how well an agent retains, organizes, and retrieves information at scale -- far beyond what fits in a single context window.
+The long-horizon memory evaluation is a stress test for AI agent memory systems.
+It generates a structured dialogue of up to 5000 turns, feeds each turn to the
+agent's `learn()` method, then quizzes the agent on details from various points
+in the conversation. The goal is to measure how well an agent retains, organizes,
+and retrieves information at scale -- far beyond what fits in a single context
+window.
 
 Key capabilities tested:
+
 - **Needle-in-haystack retrieval**: Finding specific facts buried among thousands of turns
 - **Temporal evolution tracking**: Understanding how values change over time
 - **Numerical precision**: Exact recall of numbers, percentages, and metrics
@@ -18,11 +24,44 @@ Key capabilities tested:
 - **Problem solving**: Applying stored knowledge to solve new problems
 - **Multi-hop reasoning**: Chaining multiple facts to answer complex questions
 
+## Quick Start
+
+### Run Single-Agent Eval
+
+```bash
+python -m amplihack.eval.long_horizon_memory \
+  --turns 300 --questions 50 \
+  --model claude-sonnet-4-6 \
+  --grader-model claude-haiku-4-5-20251001 \
+  --output-dir /tmp/eval-results
+```
+
+### Common Options
+
+```bash
+# Small smoke test
+python -m amplihack.eval.long_horizon_memory \
+  --turns 100 --questions 20
+
+# Large-scale stress test
+python -m amplihack.eval.long_horizon_memory \
+  --turns 5000 --questions 200 --grader-votes 5 --seed 42
+
+# Large-scale with subprocess segmentation (prevents OOM on 5000+ turns)
+python -m amplihack.eval.long_horizon_memory \
+  --turns 5000 --segment-size 100
+
+# Parallel workers for faster learning phase
+python -m amplihack.eval.long_horizon_memory \
+  --turns 1000 --questions 100 --parallel-workers 10
+```
+
 ## How Dialogue Generation Works
 
 ### Deterministic Generation
 
-All dialogue content is template-based. No LLM is needed for data generation. The same seed always produces identical output:
+All dialogue content is template-based. No LLM is needed for data generation.
+The same seed always produces identical output:
 
 ```python
 from amplihack_eval.data.long_horizon import generate_dialogue, generate_questions
@@ -33,7 +72,8 @@ questions = generate_questions(gt, num_questions=50)
 
 ### The 12 Information Blocks
 
-The dialogue is divided into 12 thematic blocks, each allocated a proportional range of the total turns. For a 5000-turn dialogue:
+The dialogue is divided into 12 thematic blocks, each allocated a proportional
+range of the total turns. For a 5000-turn dialogue:
 
 ```
 Block  1: People              (turns    1-  250,  5%)  -- personal details, preferences
@@ -54,29 +94,50 @@ Turn counts scale linearly. A 100-turn dialogue uses 1/50th of each range.
 
 ### Block Details
 
-**Block 1: People** -- 10 team members with detailed personal profiles (name, birthday, allergy, hobby, role, team, pet, hometown, favorite food, degree). Each person's facts are delivered across multiple turns with natural-language context.
+**Block 1: People** -- 10 team members with detailed personal profiles (name,
+birthday, allergy, hobby, role, team, pet, hometown, favorite food, degree). Each
+person's facts are delivered across multiple turns with natural-language context.
 
-**Block 2: Projects** -- 5 projects (Atlas, Beacon, Cascade, Delta, Echo) each with initial descriptions and a series of updates that change deadlines, budgets, team sizes, and project leads at specific turn offsets. This tests temporal evolution tracking.
+**Block 2: Projects** -- 5 projects (Atlas, Beacon, Cascade, Delta, Echo) each
+with initial descriptions and a series of updates that change deadlines, budgets,
+team sizes, and project leads at specific turn offsets. This tests temporal
+evolution tracking.
 
-**Block 3: Technical** -- Facts from 9 technical domains: programming, security, databases, cloud, ML/AI, DevOps, architecture, frontend. Each fact is a standalone technical statement (e.g., "PostgreSQL 16 improved parallel query performance by 40%").
+**Block 3: Technical** -- Facts from 9 technical domains: programming, security,
+databases, cloud, ML/AI, DevOps, architecture, frontend. Each fact is a standalone
+technical statement.
 
-**Block 4: Evolving Story** -- A multi-chapter narrative about a startup's journey with deliberate corrections and updates. Tests the agent's ability to track the most current version of facts.
+**Block 4: Evolving Story** -- A multi-chapter narrative about a startup's journey
+with deliberate corrections and updates. Tests the agent's ability to track the
+most current version of facts.
 
-**Block 5: Numerical** -- 30 precise metrics (Q1 revenue, server uptime, test coverage, API response times, etc.) with specific values and context details. Tests numerical precision.
+**Block 5: Numerical** -- 30 precise metrics (Q1 revenue, server uptime, test
+coverage, API response times, etc.) with specific values and context details.
+Tests numerical precision.
 
-**Block 6: Contradictory** -- 8 topics where 2-3 different sources provide conflicting claims (e.g., Q3 revenue: Finance says $5.2M, Auditor says $4.8M, Board says $5.0M). Tests the agent's ability to acknowledge and reason about contradictions.
+**Block 6: Contradictory** -- 8 topics where 2-3 different sources provide
+conflicting claims. Tests the agent's ability to acknowledge and reason about
+contradictions.
 
-**Block 7: Callbacks** -- References back to facts from earlier blocks, creating cross-references that require connecting information across different topics.
+**Block 7: Callbacks** -- References back to facts from earlier blocks, creating
+cross-references that require connecting information across different topics.
 
-**Block 8: Distractors** -- 30 irrelevant fun facts (e.g., "Octopuses have three hearts and blue blood") designed to test whether the agent can filter relevant from irrelevant information.
+**Block 8: Distractors** -- 30 irrelevant fun facts designed to test whether the
+agent can filter relevant from irrelevant information.
 
-**Block 9: Security Logs** -- Structured security events with timestamps, source IPs, event types, users, and severity levels. Includes attack patterns (brute force SSH, SQL injection, data exfiltration, C2 communication) that require pattern recognition.
+**Block 9: Security Logs** -- Structured security events with timestamps, source
+IPs, event types, users, and severity levels. Includes attack patterns that
+require pattern recognition.
 
-**Block 10: Incidents** -- Incident reports with evolving status updates (open -> investigating -> identified -> resolved). Each incident has a timeline of events that tests temporal tracking.
+**Block 10: Incidents** -- Incident reports with evolving status updates
+(open -> investigating -> identified -> resolved). Each incident has a timeline
+of events that tests temporal tracking.
 
-**Block 11: Infrastructure** -- Server and network inventory with detailed specifications (CPU, RAM, storage, OS, location, uptime).
+**Block 11: Infrastructure** -- Server and network inventory with detailed
+specifications (CPU, RAM, storage, OS, location, uptime).
 
-**Block 12: Problem Solving** -- Problem descriptions paired with solutions, testing the agent's ability to recall and apply stored problem-solving knowledge.
+**Block 12: Problem Solving** -- Problem descriptions paired with solutions,
+testing the agent's ability to recall and apply stored problem-solving knowledge.
 
 ### Ground Truth Tracking
 
@@ -92,6 +153,7 @@ class GroundTruth:
 ```
 
 Each `Turn` records:
+
 - `turn_number` -- position in the dialogue
 - `content` -- the text delivered to the agent
 - `block` -- which block (1-12) this turn belongs to
@@ -100,7 +162,9 @@ Each `Turn` records:
 
 ## The 15 Question Categories
 
-Questions are generated from the ground truth data. Each question has an expected answer, relevant turn numbers, scoring dimensions, and an optional deterministic grading rubric.
+Questions are generated from the ground truth data. Each question has an expected
+answer, relevant turn numbers, scoring dimensions, and an optional deterministic
+grading rubric.
 
 ### 1. `needle_in_haystack`
 
@@ -110,121 +174,80 @@ Questions are generated from the ground truth data. Each question has an expecte
 
 **Scoring dimensions**: `factual_accuracy`, `specificity`
 
-**Why it matters**: The most fundamental memory capability. If an agent cannot find a specific fact in its memory, nothing else works.
-
 ### 2. `temporal_evolution`
 
 **What it tests**: Tracking how values change over time, including computing differences.
 
-**Example**: "What is the current deadline for Project Atlas, and how many times has it changed?" (Expected: "September 20, changed twice: June 15 -> August 3 -> September 20")
+**Example**: "What is the current deadline for Project Atlas, and how many times has it changed?"
 
 **Scoring dimensions**: `factual_accuracy`, `temporal_awareness`
-
-**Why it matters**: Real-world information evolves constantly. Agents must track the current state while being aware of historical changes.
 
 ### 3. `numerical_precision`
 
 **What it tests**: Exact recall of numbers, percentages, and metrics.
 
-**Example**: "What is the Q1 revenue and how does it compare to the forecast?" (Expected: "$4.7M, 12% above forecast of $4.2M")
+**Example**: "What is the Q1 revenue and how does it compare to the forecast?"
 
 **Scoring dimensions**: `factual_accuracy`, `specificity`
-
-**Why it matters**: Approximate recall is insufficient for financial data, metrics, and technical specifications.
 
 ### 4. `source_attribution`
 
 **What it tests**: Correctly attributing claims to their original sources, especially when multiple sources discuss the same topic.
 
-**Example**: "According to the Finance Department, what is Q3 revenue?" (Expected: "$5.2M, includes deferred revenue")
-
 **Scoring dimensions**: `factual_accuracy`, `source_attribution`
-
-**Why it matters**: In environments with multiple information sources, knowing who said what is as important as knowing the facts themselves.
 
 ### 5. `cross_reference`
 
 **What it tests**: Connecting facts across different information blocks.
 
-**Example**: "Sarah Chen leads Project Atlas. What is her educational background?" (requires connecting Block 2 project data with Block 1 people data)
-
 **Scoring dimensions**: `factual_accuracy`, `specificity`
-
-**Why it matters**: Real-world knowledge is interconnected. Agents must link related facts across different contexts.
 
 ### 6. `distractor_resistance`
 
 **What it tests**: Answering questions accurately while ignoring irrelevant information.
 
-**Example**: "What is the company's Q1 revenue? Note: do not confuse with the fact that honey never spoils." (Expected: "$4.7M")
-
 **Scoring dimensions**: `factual_accuracy`, `confidence_calibration`
-
-**Why it matters**: Memory systems that retrieve by similarity can be fooled by distractors. This tests precision of retrieval.
 
 ### 7. `meta_memory`
 
 **What it tests**: The agent's awareness of what it knows and does not know.
 
-**Example**: "How many distinct people have you been told about?" (Expected: count of people from Block 1)
-
 **Scoring dimensions**: `factual_accuracy`, `confidence_calibration`
-
-**Why it matters**: Agents that can reason about their own knowledge are more reliable and trustworthy.
 
 ### 8. `security_log_analysis`
 
 **What it tests**: Pattern recognition in structured security event data.
 
-**Example**: "What IP address was involved in the brute force SSH attack?" (Expected: "192.168.1.45")
-
 **Scoring dimensions**: `factual_accuracy`, `specificity`
-
-**Why it matters**: Security analysis requires precise recall of structured data including IPs, timestamps, and event sequences.
 
 ### 9. `incident_tracking`
 
 **What it tests**: Following incident timelines and status evolution.
 
-**Example**: "What is the current status of Incident INC-001, and when was the root cause identified?"
-
 **Scoring dimensions**: `factual_accuracy`, `temporal_awareness`
-
-**Why it matters**: Incident management requires tracking evolving states across multiple updates.
 
 ### 10. `infrastructure_knowledge`
 
 **What it tests**: Recall of technical infrastructure details.
 
-**Example**: "What is the CPU specification of server web-prod-01?" (Expected: specific CPU model and specs)
-
 **Scoring dimensions**: `factual_accuracy`, `specificity`
-
-**Why it matters**: Infrastructure queries require exact recall of configuration details.
 
 ### 11. `problem_solving`
 
 **What it tests**: Recalling stored problem-solution pairs and applying them.
 
-**Example**: "A user reports their application is running slowly after a deployment. What was the recommended diagnostic approach?"
-
 **Scoring dimensions**: `factual_accuracy`, `specificity`
-
-**Why it matters**: The ultimate purpose of stored knowledge is application to solve problems.
 
 ### 12. `multi_hop_reasoning`
 
 **What it tests**: Chaining multiple facts to answer a question that requires 2+ retrieval steps.
 
-**Example**: "The lead of Project Echo was recently changed. What team is the new lead originally from?" (requires: Echo's new lead -> that person's team)
-
 **Scoring dimensions**: `factual_accuracy`, `specificity`
 
-**Why it matters**: Complex questions rarely have answers in a single fact. Multi-hop reasoning tests the agent's ability to compose knowledge.
+### 13-15. Additional Categories
 
-### 13-15. Additional Categories (generated from blocks)
-
-The question generator also produces additional questions that combine categories -- for example, temporal + numerical ("What was the budget change for Project Atlas and when did it happen?") or cross-reference + security ("Which team member from the Security team had events logged in the security block?").
+The question generator also produces additional questions that combine categories
+-- for example, temporal + numerical or cross-reference + security.
 
 ## The Grading System
 
@@ -233,12 +256,14 @@ The question generator also produces additional questions that combine categorie
 Each question is graded on multiple dimensions using a two-tier approach:
 
 **Tier 1 -- Deterministic grading** (instant, free, reproducible):
+
 - Checks `required_keywords` against the answer (case-insensitive)
 - Awards bonus for `acceptable_paraphrases` found
 - Scores 0.0 if any `incorrect_patterns` match
 - Applies to `factual_accuracy` and `specificity` dimensions
 
 **Tier 2 -- LLM semantic grading** (slower, costs API calls, nuanced):
+
 - Used for `temporal_awareness`, `source_attribution`, `confidence_calibration`
 - Also used when no deterministic rubric is available
 - Prompt includes scoring guide and dimension descriptions
@@ -246,7 +271,9 @@ Each question is graded on multiple dimensions using a two-tier approach:
 
 ### Multi-Vote Stability
 
-To reduce LLM grading noise, each question is graded N times (configurable, default 3). For each dimension, the median score is taken as the final grade. The reasoning from the vote closest to the median is preserved.
+To reduce LLM grading noise, each question is graded N times (configurable,
+default 3). For each dimension, the median score is taken as the final grade.
+The reasoning from the vote closest to the median is preserved.
 
 ```
 Vote 1: factual_accuracy = 0.85
@@ -254,28 +281,18 @@ Vote 2: factual_accuracy = 0.90    -> Median: 0.85
 Vote 3: factual_accuracy = 0.80
 ```
 
-For deterministic dimensions, multi-vote has zero overhead since the score is identical every time.
-
-### Dimension Weights
-
-Questions can specify custom dimension weights via their rubric:
-
-```python
-GradingRubric(
-    required_keywords=["Paris"],
-    dimension_weights={"factual_accuracy": 1.5, "specificity": 0.5}
-)
-```
+For deterministic dimensions, multi-vote has zero overhead since the score is
+identical every time.
 
 ### Scoring Scale
 
-| Score | Meaning                                       |
-|-------|-----------------------------------------------|
-| 1.0   | Perfect or semantically equivalent             |
-| 0.8-0.9 | Correct main points, minor differences      |
-| 0.5-0.7 | Partially correct, missing key details      |
-| 0.2-0.4 | Some relevant content, significant gaps     |
-| 0.0-0.1 | Incorrect or irrelevant                     |
+| Score | Meaning |
+|-------|---------|
+| 1.0 | Perfect or semantically equivalent |
+| 0.8-0.9 | Correct main points, minor differences |
+| 0.5-0.7 | Partially correct, missing key details |
+| 0.2-0.4 | Some relevant content, significant gaps |
+| 0.0-0.1 | Incorrect or irrelevant |
 
 ## How to Interpret Results
 
@@ -307,30 +324,19 @@ Category                     Avg      Min      Max   Count
 -----------------------------------------------------------------------
 cross_reference            85.00%   70.00%   95.00%      10
 distractor_resistance      92.00%   80.00%  100.00%       8
-meta_memory                78.00%   60.00%   90.00%       5
 needle_in_haystack         88.00%   65.00%  100.00%      20
 numerical_precision        82.00%   55.00%   95.00%      15
-security_log_analysis      90.00%   80.00%  100.00%       8
-source_attribution         75.00%   50.00%   90.00%      10
-temporal_evolution          70.00%   40.00%   90.00%      15
+...
 ```
 
-**Focus on the weakest categories.** Categories below 70% indicate systematic weaknesses in the agent's memory system. The min score reveals worst-case performance.
-
-### Dimension Averages
-
-```
-DIMENSION AVERAGES BY CATEGORY:
-  needle_in_haystack: factual_accuracy: 90%, specificity: 86%
-  temporal_evolution: factual_accuracy: 75%, temporal_awareness: 65%
-  source_attribution: factual_accuracy: 80%, source_attribution: 70%
-```
-
-If `factual_accuracy` is high but `temporal_awareness` is low, the agent can recall facts but struggles with temporal ordering. If `source_attribution` is low, the agent retrieves facts but loses track of their origins.
+**Focus on the weakest categories.** Categories below 70% indicate systematic
+weaknesses in the agent's memory system. The min score reveals worst-case
+performance.
 
 ### The Worst 5 Questions
 
-The report highlights the 5 lowest-scoring questions. These are the best starting points for debugging:
+The report highlights the 5 lowest-scoring questions. These are the best starting
+points for debugging:
 
 ```
 WORST 5 QUESTIONS:
@@ -339,7 +345,8 @@ WORST 5 QUESTIONS:
     Got: The budget is $2.5M.
 ```
 
-This example shows the agent knows the current value but lost the change history -- a temporal awareness issue.
+This example shows the agent knows the current value but lost the change history
+-- a temporal awareness issue.
 
 ## Performance Characteristics
 
@@ -347,35 +354,32 @@ This example shows the agent knows the current value but lost the change history
 
 | Turns | Questions | Typical Facts | Generation Time | Learning Time* |
 |-------|-----------|---------------|-----------------|---------------|
-| 100   | 20        | ~80           | < 0.1s          | Depends on agent |
-| 500   | 50        | ~400          | < 0.5s          | Depends on agent |
-| 1000  | 100       | ~800          | < 1s            | Depends on agent |
-| 5000  | 200       | ~4000         | < 5s            | Depends on agent |
+| 100 | 20 | ~80 | < 0.1s | Depends on agent |
+| 500 | 50 | ~400 | < 0.5s | Depends on agent |
+| 1000 | 100 | ~800 | < 1s | Depends on agent |
+| 5000 | 200 | ~4000 | < 5s | Depends on agent |
 
-*Learning time depends entirely on the agent implementation -- a simple list-based agent will be much faster than one using LLM-powered ingestion.
+*Learning time depends entirely on the agent implementation -- a simple list-based
+agent will be much faster than one using LLM-powered ingestion.
 
 ### Grading Costs
 
 - **Deterministic grading**: Free, instant (no API calls)
 - **LLM grading**: 1 API call per dimension per vote per question
 - **Example**: 100 questions * 3 LLM dimensions * 3 votes = 900 API calls
-- **Typical cost**: ~$0.50 for 100 questions with 3-vote grading (Sonnet model)
 
 ### Reproducibility
 
-Same seed + same agent = same scores (within LLM grading variance). Multi-vote and multi-seed evaluation reduce this variance. For fully deterministic results, set all question rubrics and use `grading_mode="deterministic"`.
+Same seed + same agent = same scores (within LLM grading variance). Multi-vote
+and multi-seed evaluation reduce this variance. For fully deterministic results,
+set all question rubrics and use `grading_mode="deterministic"`.
 
 ## Pre-built Datasets
 
-### Skip the 4+ Hour Learning Phase
+### Skip the Learning Phase
 
-The 5000-turn learning phase takes 4+ hours and requires 10,000+ LLM API calls. Pre-built datasets let you skip this entirely and jump straight to evaluation.
-
-### Available Datasets
-
-| Name | Turns | Seed | Facts | Baseline Score | Size |
-|------|-------|------|-------|---------------|------|
-| `5000t-seed42-v1.0` | 5,000 | 42 | 762 | 90.47% | 1.3 MB |
+The 5000-turn learning phase takes hours and requires thousands of LLM API calls.
+Pre-built datasets let you skip this entirely and jump straight to evaluation.
 
 ### Download and Use
 
@@ -386,7 +390,7 @@ amplihack-eval list-datasets
 # Download a pre-built dataset
 amplihack-eval download-dataset 5000t-seed42-v1.0
 
-# Run evaluation using the pre-built DB (skip 4+ hour learning phase)
+# Run evaluation using the pre-built DB (skip learning phase)
 amplihack-eval run \
   --adapter learning-agent \
   --skip-learning \
@@ -416,17 +420,22 @@ adapter = LearningAgentAdapter(storage_path=path / "memory_db")
 ### Dataset Structure
 
 Each dataset contains:
-- `metadata.json` -- Configuration and provenance (turns, seed, facts, baseline score, code version)
+
+- `metadata.json` -- Configuration and provenance (turns, seed, facts, code version)
 - `baseline_results.json` -- Full evaluation scores at time of creation
 - `memory_db/` -- Kuzu graph database (the pre-built learning DB)
 
-Datasets are distributed via [GitHub Releases](https://github.com/rysweet/amplihack-agent-eval/releases) to keep the repository lightweight.
+Datasets are distributed via [GitHub Releases](https://github.com/rysweet/amplihack-agent-eval/releases)
+to keep the repository lightweight.
 
 ## CLI Usage
 
 ```bash
 # Basic evaluation (100 turns, 20 questions)
 amplihack-eval run --turns 100 --questions 20 --adapter http --agent-url http://localhost:8000
+
+# With LearningAgent
+amplihack-eval run --turns 100 --adapter learning-agent --model claude-sonnet-4-6
 
 # Large-scale stress test
 amplihack-eval run --turns 5000 --questions 200 --grader-votes 5 --seed 42
@@ -437,13 +446,6 @@ amplihack-eval run --adapter learning-agent --skip-learning \
 
 # Multi-seed comparison
 amplihack-eval compare --seeds 42,123,456,789 --turns 100 --questions 20
-
-# With LearningAgent
-amplihack-eval run --turns 100 --adapter learning-agent --model claude-sonnet-4-5-20250929
-
-# Dataset management
-amplihack-eval list-datasets
-amplihack-eval download-dataset 5000t-seed42-v1.0
 ```
 
 ## Programmatic Usage
@@ -456,7 +458,7 @@ agent = MyAgent()
 
 # Run evaluation
 runner = EvalRunner(num_turns=1000, num_questions=100, seed=42, grader_votes=3)
-report = runner.run(agent, grader_model="claude-sonnet-4-5-20250929")
+report = runner.run(agent, grader_model="claude-sonnet-4-6")
 
 # Inspect results
 print(f"Overall: {report.overall_score:.2%}")

--- a/docs/azure-hive-qa-eval.md
+++ b/docs/azure-hive-qa-eval.md
@@ -1,219 +1,190 @@
-# Azure Hive Q&A Eval Tutorial
+# Running Distributed Eval on Azure
 
-This tutorial explains how to run a Q&A evaluation against the **live Azure
-Hive Mind** — 20 agents deployed as Azure Container Apps, sharing knowledge
-via a distributed hash table (DHT) over Azure Service Bus.
+This guide covers how to deploy a distributed hive mind to Azure, feed it
+content, and run a Q&A evaluation against the live agents.
 
-## What This Eval Does
+## Architecture Overview
 
-`query_hive.py` sends a `network_graph.search_query` event to the live hive
-via the Service Bus topic `hive-graph`. Each running agent receives the query,
-searches its local knowledge shard, and publishes a `network_graph.search_response`
-back. The eval script collects these responses and scores them against expected
-keywords.
+The distributed eval deploys N agents as Azure Container Apps. Each agent holds
+a shard of the distributed knowledge graph (DistributedHiveGraph). Agents
+communicate via Azure Service Bus topics. The eval script sends questions as
+events and collects answers from Log Analytics.
 
 ```
-query_hive.py ──publishes──► hive-graph topic
-                                     │
-                    ┌────────────────┼────────────────┐
-                    ▼                ▼                ▼
-              agent-0 sub      agent-1 sub   …  agent-19 sub
-              (Container App)  (Container App)   (Container App)
-                    │                │                │
-                    └────────────────┼────────────────┘
-                                     ▼
-                          eval-query-agent sub
-                          (responses collected here)
+feed_content.py ──publishes──► Service Bus topic (hive-events)
+                                       │
+                      ┌────────────────┼────────────────┐
+                      ▼                ▼                ▼
+                agent-0 sub      agent-1 sub   …  agent-N sub
+                (Container App)  (Container App)   (Container App)
+                      │                │                │
+                      └────────────────┼────────────────┘
+                                       ▼
+                            query_hive.py collects
+                            answers from Log Analytics
 ```
 
 ## Prerequisites
 
-```bash
-# Install the azure-servicebus SDK
-pip install azure-servicebus
+- **Azure CLI** authenticated (`az login`)
+- **ANTHROPIC_API_KEY** set in your environment
+- **Docker** daemon running (for image build)
+- **amplihack** repo cloned with `.venv` activated
+- **azure-servicebus** Python package installed (`pip install azure-servicebus`)
 
-# Clone the amplihack repo on the feat/distributed-hive-mind branch
-git clone https://github.com/rysweet/amplihack5 /path/to/amplihack
-cd /path/to/amplihack
-git checkout feat/distributed-hive-mind
-```
-
-The live hive is already deployed in Azure resource group `hive-mind-rg`.
-No Azure credentials are required to query it — the connection string is
-embedded in `query_hive.py` as a default.
-
-To use your own hive, set:
+## Step 1: Deploy Agents
 
 ```bash
-export HIVE_CONNECTION_STRING="Endpoint=sb://YOUR-NS.servicebus.windows.net/;..."
-export HIVE_TOPIC="hive-graph"
-export HIVE_SUBSCRIPTION="eval-query-agent"
-export HIVE_TIMEOUT="10"
+export ANTHROPIC_API_KEY="$(cat ~/.msec-k)"  # or your key source
+
+HIVE_NAME=amplihive \
+HIVE_RESOURCE_GROUP=hive-mind-rg \
+HIVE_LOCATION=westus2 \
+HIVE_AGENT_COUNT=100 \
+HIVE_AGENTS_PER_APP=5 \
+HIVE_AGENT_MODEL=claude-sonnet-4-6 \
+bash deploy/azure_hive/deploy.sh
 ```
 
-## Running the Built-In Q&A Eval
+This provisions:
+
+- Resource group and Azure Container Registry (ACR)
+- Azure Service Bus namespace, topic, and per-agent subscriptions
+- Container Apps Environment
+- N Container Apps (`ceil(HIVE_AGENT_COUNT / HIVE_AGENTS_PER_APP)` apps)
+
+To check deployment status:
 
 ```bash
-cd /path/to/amplihack
-
-# Run all 15 questions, print results to stdout
-python experiments/hive_mind/query_hive.py --run-eval
-
-# Write results to JSON
-python experiments/hive_mind/query_hive.py --run-eval --output results.json
-
-# Adjust timeout if agents are slow to respond
-python experiments/hive_mind/query_hive.py --run-eval --timeout 15
+bash deploy/azure_hive/deploy.sh --status
 ```
 
-### Example Output
+## Step 2: Feed Content
 
-```
-======================================================================
-LIVE AZURE HIVE Q&A EVAL
-Hive: hive-sb / topic: hive-graph
-Questions: 15
-Timeout per query: 10s
-======================================================================
+Retrieve the Service Bus connection string and feed dialogue turns to the hive:
 
-Domain               Hit   Results  | Question
-----------------------------------------------------------------------
-  biology            HIT   7 results | What are cells made of?
-  biology            HIT   5 results | How does DNA store information?
-  biology            MISS  0 results | What do enzymes do?
-  chemistry          HIT   8 results | What is the structure of water?
-  ...
+```bash
+SB_CONN=$(az servicebus namespace authorization-rule keys list \
+  -g hive-mind-rg \
+  --namespace-name <YOUR-SB-NAMESPACE> \
+  --name RootManageSharedAccessKey \
+  --query primaryConnectionString -o tsv)
 
-======================================================================
-RESULTS
-======================================================================
-  Overall:   11/15 (73.3%)
-
-  By domain:
-    biology             : 2/3 (67%)
-    chemistry           : 3/3 (100%)
-    computer_science    : 2/3 (67%)
-    mathematics         : 2/3 (67%)
-    physics             : 2/3 (67%)
-
-  Total time: 38.42s
-======================================================================
+AMPLIHACK_MEMORY_CONNECTION_STRING="$SB_CONN" \
+AMPLIHACK_TOPIC_NAME="hive-events" \
+python deploy/azure_hive/feed_content.py --turns 5000
 ```
 
-## Running a Single Query
+Replace `<YOUR-SB-NAMESPACE>` with the Service Bus namespace created by the
+deploy script (visible in `--status` output).
+
+## Step 3: Wait for Processing
+
+Poll Log Analytics to confirm agents are processing content:
+
+```bash
+LA_ID=$(az monitor log-analytics workspace list \
+  -g hive-mind-rg \
+  --query "[0].customerId" -o tsv)
+
+az monitor log-analytics query -w "$LA_ID" \
+  --analytics-query "ContainerAppConsoleLogs_CL | where TimeGenerated > ago(2m) | where Log_s has 'Completed Call' | count"
+```
+
+Wait until the count stops increasing, indicating agents have finished
+processing all turns.
+
+## Step 4: Run Eval
 
 ```bash
 python experiments/hive_mind/query_hive.py \
-    --query "What is Newton's second law?" \
-    --timeout 10
-
-# Output:
-# Querying live hive: "What is Newton's second law?"
-# Results (3):
-#   1. [0.97] F equals ma is Newton's second law
-#        concept: mechanics
-#        source:  agent-7
+  --ooda-eval \
+  --repeats 1 \
+  --connection-string "$SB_CONN" \
+  --workspace-id "$LA_ID" \
+  --topic hive-events \
+  --answer-wait 600 \
+  --output results.json
 ```
 
-## Q&A Eval Dataset
+### Alternative: Run the keyword-match eval
 
-The built-in eval covers 15 questions across 5 domains (3 per domain):
-
-| Domain | Questions |
-|---|---|
-| biology | cells, DNA, enzymes |
-| chemistry | water structure, covalent bonds, pH |
-| physics | Newton's 2nd law, speed of light, E=mc² |
-| mathematics | Pythagorean theorem, derivatives, Pi |
-| computer_science | binary search complexity, ACID, CAP theorem |
-
-Each question is scored by keyword matching: a hit requires **all expected
-keywords** to appear in at least one result from the hive.
-
-## Scoring
-
-The eval uses a binary keyword-match scoring scheme:
-
-- **Hit**: at least one returned fact contains all expected keywords
-- **Miss**: no returned fact contains all expected keywords
-
-Overall accuracy = `hits / total_questions`.
-
-## Understanding the Results
-
-### Why Do MISS Results Occur?
-
-1. **Agent asleep**: Azure Container Apps scale to zero after inactivity. The
-   Container App runtime needs time to wake up (cold start ~30s).
-2. **Shard miss**: The query hit the wrong shard owners (DHT routing is based
-   on keyword hashing, not semantic similarity).
-3. **Knowledge gap**: The specific fact was not promoted to the shared hive
-   (it may be in local Kuzu memory only).
-4. **Timeout too short**: Increase `--timeout` if agents need more time.
-
-### Waking Up Agents
-
-If agents are cold-started (zero instances), send a warmup query first:
+For a faster sanity check using keyword matching instead of LLM grading:
 
 ```bash
-# Warmup query — agents will start responding within 30s
-python experiments/hive_mind/query_hive.py --query "warmup" --timeout 30
-
-# Then run the eval
-python experiments/hive_mind/query_hive.py --run-eval --timeout 15
+python experiments/hive_mind/query_hive.py \
+  --seed --run-eval \
+  --connection-string "$SB_CONN" \
+  --topic hive-events \
+  --output results.json
 ```
 
-## Adding Custom Questions
+### Run eval multiple times for statistical stability
 
-Edit `QA_EVAL_DATASET` in `query_hive.py`:
-
-```python
-QA_EVAL_DATASET = [
-    # (domain, question, expected_keywords)
-    ("my_domain", "What is X?", ["keyword1", "keyword2"]),
-    ...
-]
+```bash
+python experiments/hive_mind/query_hive.py \
+  --ooda-eval \
+  --repeats 3 \
+  --connection-string "$SB_CONN" \
+  --workspace-id "$LA_ID" \
+  --topic hive-events \
+  --answer-wait 600 \
+  --output results.json
 ```
 
-Or pass a custom dataset programmatically:
+## Step 5: Cleanup
 
-```python
-from experiments.hive_mind.query_hive import HiveQueryClient, _score_response
+Remove all Azure resources when done:
 
-client = HiveQueryClient(timeout=10)
-results = client.query("What is Newton's second law?")
-hit = _score_response(results, ["F", "ma"])
-client.close()
+```bash
+bash deploy/azure_hive/deploy.sh --cleanup
 ```
 
-## Architecture Reference
+Or delete the resource group directly:
 
-| Component | Value |
-|---|---|
-| Azure resource group | `hive-mind-rg` |
-| Service Bus namespace | See `HIVE_CONNECTION_STRING` env var |
-| Topic | `hive-graph` |
-| Eval subscription | `eval-query-agent` |
-| Agent subscriptions | `agent-0` … `agent-19` |
-| Agent containers | `amplihive-app-0` … `amplihive-app-19` |
-| Knowledge shard backend | In-memory DHT (DistributedHiveGraph) |
-| Query protocol | `network_graph.search_query` / `network_graph.search_response` |
+```bash
+az group delete -n hive-mind-rg --yes
+```
 
-## Related Documentation
+## Key Environment Variables
 
-- `docs/hive-mind-eval.md` — Hive Mind eval strategy and full topology guide
-- `experiments/hive_mind/query_hive.py` — The query/eval script
-- `experiments/hive_mind/deploy_azure_hive.sh` — Azure deployment script
-- `src/amplihack/memory/network_store.py` — NetworkGraphStore protocol
-- `src/amplihack/agents/goal_seeking/hive_mind/event_bus.py` — Event bus
-- `docs/distributed_hive_mind.md` — Distributed hive architecture
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HIVE_NAME` | Hive deployment name | `amplihive` |
+| `HIVE_RESOURCE_GROUP` | Azure resource group | `hive-mind-rg` |
+| `HIVE_LOCATION` | Azure region | `westus2` |
+| `HIVE_AGENT_COUNT` | Total number of agents | `5` |
+| `HIVE_AGENTS_PER_APP` | Agents per Container App | `5` |
+| `HIVE_AGENT_MODEL` | LLM model for agents | `claude-sonnet-4-6` |
+| `HIVE_TRANSPORT` | Transport type | `azure_service_bus` |
+| `AMPLIHACK_TOPIC_NAME` | Service Bus topic name | `hive-events` |
+| `AMPLIHACK_MEMORY_CONNECTION_STRING` | Service Bus connection string | -- |
+| `LOG_ANALYTICS_WORKSPACE_ID` | Log Analytics workspace GUID | -- |
+| `OODA_ANSWER_WAIT` | Eval answer timeout in seconds | `600` |
 
 ## Troubleshooting
 
 | Symptom | Fix |
-|---|---|
-| `0 results` on all queries | Agents are cold-started — send warmup first |
-| `ImportError: azure-servicebus` | `pip install azure-servicebus` |
-| Timeout errors in JSON output | Increase `--timeout` to 15-30s |
-| Subscription not found | Re-run `az servicebus topic subscription create ...` |
-| All MISS, even warmup | Check `az containerapp revision list --name amplihive-app-0 --resource-group hive-mind-rg` |
+|---------|-----|
+| Rate limits (429 errors) | Agents retry with exponential backoff (2-32s). If persistent, reduce `HIVE_AGENT_COUNT` or use a smaller model (e.g., Sonnet instead of Opus). |
+| Service Bus auth errors | Ensure topic name matches agent config (`hive-events`). Verify connection string has `Send` and `Listen` claims. |
+| Missing answers in eval | Check Log Analytics for ANSWER entries. Increase `--answer-wait` beyond 600s for large deployments. |
+| `0 results` on all queries | Agents may be cold-started (Azure Container Apps scale to zero). Send a warmup query first or check `az containerapp revision list`. |
+| Subscription not found | Verify the eval subscription exists: `az servicebus topic subscription list --resource-group hive-mind-rg --namespace-name <ns> --topic-name hive-events` |
+| Deploy script fails | Ensure Docker daemon is running and `az login` is current. Check `deploy.sh --status` for partial deployments. |
+
+## Deploy Script Options
+
+```bash
+bash deploy/azure_hive/deploy.sh                 # Deploy everything
+bash deploy/azure_hive/deploy.sh --build-only    # Build + push image only
+bash deploy/azure_hive/deploy.sh --infra-only    # Provision infra only
+bash deploy/azure_hive/deploy.sh --cleanup       # Tear down resource group
+bash deploy/azure_hive/deploy.sh --status        # Show deployment status
+```
+
+## Related Documentation
+
+- [Hive Mind Eval Strategy](hive-mind-eval.md) -- Topology comparison and scoring methodology
+- [Running Evals Quick Start](running-evals.md) -- All eval types in one page
+- [Long-Horizon Memory Eval](LONG_HORIZON_EVAL.md) -- Single-agent eval details

--- a/docs/hive-mind-eval.md
+++ b/docs/hive-mind-eval.md
@@ -2,22 +2,40 @@
 
 ## What Is the Hive Mind?
 
-The hive mind is a distributed knowledge-sharing layer for LearningAgent
-instances. Instead of each agent operating in isolation with its own Kuzu
-knowledge graph, the hive mind lets agents pool facts, propagate discoveries,
-and answer questions using collective knowledge.
+The hive mind is a distributed knowledge-sharing layer for AI agents. Instead of
+each agent operating in isolation with its own knowledge graph, the hive mind
+lets agents pool facts, propagate discoveries, and answer questions using
+collective knowledge.
 
-The core abstraction is the **HiveGraph** — a shared fact store that agents
-promote facts into and query from. Two implementations exist:
+### Four-Layer Architecture
 
-- `InMemoryHiveGraph` — all facts in one shared dict; suitable for < 20 agents
-  (single-process, no network)
-- `DistributedHiveGraph` — DHT-sharded across agent shards; designed for 20–1000+
-  agents. Each agent holds `O(F/N)` facts instead of `O(F)` total. Queries fan
-  out to K shard owners (default 5) instead of all N agents.
+The hive mind is built on four layers:
 
-Different topologies control how facts flow between agents and how queries
-resolve across the network.
+| Layer | Responsibility | Implementations |
+|-------|---------------|-----------------|
+| **Storage** (HiveGraph) | Shared fact store | `InMemoryHiveGraph` (local, < 20 agents), `DistributedHiveGraph` (DHT-sharded, 20-1000+ agents) |
+| **Transport** (EventBus) | Message delivery between agents | `LocalEventBus` (in-process), Azure Service Bus (distributed) |
+| **Discovery** (Gossip) | Peer discovery and fact propagation | Gossip protocol with configurable broadcast thresholds |
+| **Query** (Dedup + Rerank) | Answer assembly from distributed shards | Fan-out to K shard owners, RRF merge, deduplication |
+
+**HiveMindOrchestrator** is the unified coordination layer that wires the four
+layers together. It manages agent lifecycle, fact promotion, query routing, and
+consensus filtering through a single entry point.
+
+### Storage Implementations
+
+- **InMemoryHiveGraph** -- All facts in one shared dict. Suitable for local
+  eval with < 20 agents (single-process, no network).
+- **DistributedHiveGraph** -- DHT-sharded across agent shards. Each agent holds
+  `O(F/N)` facts instead of `O(F)` total. Queries fan out to K shard owners
+  (default 5) instead of all N agents. Designed for 20-1000+ agents.
+
+### Transport Implementations
+
+- **LocalEventBus** -- In-process event delivery for local evaluation. No
+  network overhead.
+- **Azure Service Bus** -- Cloud-based transport for distributed deployments.
+  Each agent subscribes to a shared topic and publishes responses back.
 
 ## Why Evaluate the Hive Mind?
 
@@ -76,7 +94,7 @@ graph TD
 All N agents share one `DistributedHiveGraph`. Facts are partitioned via
 consistent hashing (DHT): each agent owns a keyspace shard and holds only
 `O(F/N)` facts. Queries fan out to K shard owners and merge via RRF. No
-federation tree overhead. Designed for 20–1000+ agents.
+federation tree overhead. Designed for 20-1000+ agents.
 
 ```mermaid
 graph TD
@@ -94,14 +112,13 @@ graph TD
     DHT -->|"fan-out to K=5 shard owners<br/>RRF merge"| Result
 ```
 
-**Key property:** Memory is `O(F/N)` per agent instead of `O(F)` total. 100
-agents: 12.3 s creation, 4.8 GB RSS (previously OOM crash with InMemoryHiveGraph).
+**Key property:** Memory is `O(F/N)` per agent instead of `O(F)` total.
 
 ### Federated
 
 N agents organized into M groups. Each group has its own hive (InMemoryHiveGraph
 or DistributedHiveGraph). A root hive connects the groups. High-confidence facts
-(≥ 0.9) broadcast across groups via the root. Lower-confidence facts stay in
+(>= 0.9) broadcast across groups via the root. Lower-confidence facts stay in
 their group but are reachable through `query_federated()` tree traversal with
 RRF merge.
 
@@ -167,10 +184,9 @@ python -m amplihack_eval.run \
 ### Parallel Learning
 
 Use `--parallel-workers` to run the learning phase with multiple agents in
-parallel. This reduces wall-clock time significantly:
+parallel:
 
 ```bash
-# 9x learning speedup with 10 parallel workers
 python -m amplihack_eval.run \
   --scenario long_horizon \
   --topology distributed \
@@ -179,12 +195,7 @@ python -m amplihack_eval.run \
   --output-dir results/distributed-parallel
 ```
 
-| Workers | Approx. wall-clock (5000 turns) | Notes |
-|---|---|---|
-| 1 (sequential) | ~21.6 hours | Baseline |
-| 10 (parallel) | ~2.4 hours | 9x speedup |
-
-Note: parallel learning introduces ordering effects — agents see different
+Note: parallel learning introduces ordering effects -- agents see different
 subsets of turns. Run with `--seed` for reproducibility.
 
 ### Skip Learning (Q&A Only)
@@ -200,28 +211,6 @@ python -m amplihack_eval.run \
   --output-dir results/flat-qa-only
 ```
 
-### Pre-Built Baseline Dataset
-
-The `5000t-seed42-v1.0` dataset ships a pre-built memory DB from the 5000-turn
-learning phase. Use it for rapid Q&A-only evaluation:
-
-```bash
-# Load the pre-built baseline (no learning phase needed)
-python -m amplihack_eval.run \
-  --scenario long_horizon \
-  --topology single \
-  --skip-learning \
-  --load-db datasets/5000t-seed42-v1.0/ \
-  --output-dir results/single-prebuilt
-```
-
-Dataset metadata:
-- **Turns**: 5000 — seed 42
-- **Facts delivered**: 762 across 12 information blocks
-- **Memory nodes**: 15,854 (10,854 semantic + 5,000 episodic)
-- **Baseline score**: 90.47% (median-of-3 grading)
-- **Date**: 2026-02-24
-
 ### Compare Results
 
 ```bash
@@ -236,7 +225,7 @@ python -m amplihack_eval.compare \
 
 ### Per-Question Grading (Median-of-3)
 
-Each question is graded on a 0.0–1.0 scale using **median-of-3 voting** to
+Each question is graded on a 0.0-1.0 scale using **median-of-3 voting** to
 reduce LLM grading noise: the grader runs 3 times per question, and the median
 score per dimension is taken as the final grade. The reasoning from the vote
 closest to the median is preserved for inspection.
@@ -290,89 +279,9 @@ A topology is better than the baseline if:
 - `temporal_trap` score does not fall below baseline (DHT sharding should not
   confuse temporal ordering)
 
-## Latest Results
-
-Results from the `5000t-seed42-v1.0` dataset (5000 turns, seed 42, 100 questions
-across 15 categories). Median-of-3 grading. Scores are median across 3 seeds
-unless noted.
-
-### Single-Agent Baseline
-
-| Category | Score |
-|---|---|
-| cross_reference | 100.0% |
-| distractor_resistance | 100.0% |
-| infrastructure_knowledge | 100.0% |
-| meta_memory | 100.0% |
-| needle_in_haystack | 100.0% |
-| problem_solving | 100.0% |
-| security_log_analysis | 98.3% |
-| source_attribution | 99.5% |
-| multi_hop_reasoning | 92.5% |
-| numerical_precision | 100.0% |
-| numerical_reasoning | 86.9% |
-| temporal_evolution | 89.7% |
-| adversarial_distractor | 89.6% |
-| incident_tracking | 83.8% |
-| temporal_trap | 53.3% |
-| **Overall** | **90.47%** |
-
-### Multi-Agent Topology Comparison
-
-| Topology | Agents | Median Score | Std Dev | Notes |
-|---|---|---|---|---|
-| Single agent | 1 | **90.47%** | — | Baseline, dataset 5000t-seed42-v1.0 |
-| Federated smoke test | 10 | 65.7% | 6.7% | Best multi-agent, lowest variance |
-| Distributed single DHT | 20 | 47.2% | — | One DistributedHiveGraph, no federation tree |
-| Federated 100 agents | 100 | 45.8% | 21.7% | Routing precision degrades at scale |
-| Federated semantic+OODA | 10 | 45.8% | 21.7% | OODA-integrated routing |
-| Federated v1 naive | 5 | 40.0% | — | Longest-answer-wins merge (deprecated) |
-| Federated broken routing | 5 | 34.9% | 31.2% | Root hive empty; root bug (fixed) |
-
-### Key Findings
-
-**Single DHT (`DistributedHiveGraph`):**
-- 47.2% median — competitive with federated approaches at large scale
-- Memory: `O(F/N)` per agent vs `O(F)` total for InMemoryHiveGraph
-- 100 agents: 12.3 s creation, 4.8 GB RSS (previously OOM crash)
-- Avoids federation tree overhead — simpler routing, lower latency
-
-**Parallel learning:**
-- 9x wall-clock speedup with 10 workers (21.6 h → 2.4 h for 5000 turns)
-- Works with both InMemoryHiveGraph and DistributedHiveGraph
-- Introduces ordering effects — use fixed seed for reproducibility
-- Score impact: not yet measured independently (confounded with topology)
-
-**Variance:**
-- Broken routing had 31.2% stddev — results ranged 23%–83%
-- Smoke test (10 agents) had 6.7% stddev — most reproducible multi-agent setup
-- Federated 100 agents: 21.7% stddev — scale amplifies routing sensitivity
-
-**Gap to close:** 90.47% (single) − 65.7% (best multi-agent) = **24.77 pp**
-
-### Path to Closing the Gap
-
-1. **Domain-aware routing** — route queries to agents that learned domain-specific
-   content, not random shard owners
-2. **Consensus-weighted retrieval** — fact confidence boosted by confirmation count
-   across agents (CONFIRMED_BY edges)
-3. **Adversarial consensus filtering** — require ≥ 2 agent confirmations before
-   promoting facts from low-trust sources
-4. **Temporal-aware reranking** — give recency preference to time-ordered facts,
-   which are the primary failure mode (`temporal_trap`: 53.3%)
-5. **Pre-built DHT warm-up** — populate the DHT from the pre-built baseline
-   dataset before the Q&A phase (eliminates cold-start penalty)
-
 ## References
 
-- **amplihack PR [#2717](https://github.com/rysweet/amplihack5/pull/2717)**:
-  Hive mind implementation (InMemoryHiveGraph, CRDTs, gossip, federation)
-- **amplihack PR [#2876](https://github.com/rysweet/amplihack5/pull/2876)**:
-  DistributedHiveGraph — DHT sharding for 100+ agents
-- **amplihack issue [#2839](https://github.com/rysweet/amplihack5/issues/2839)**:
-  Hive mind eval scenarios tracking issue
-- **Dataset**: `datasets/5000t-seed42-v1.0/` — pre-built 5000-turn baseline DB
 - **Architecture doc**: `docs/hive_mind/ARCHITECTURE.md` in the amplihack repo
 - **Tutorial**: `docs/tutorial_prompt_to_distributed_hive.md` in the amplihack repo
-- **Azure resources**: resource group `hive-mind-rg`, registry `hivacrhivemind`,
-  Service Bus `hive-sb-dj2qo2w7vu5zi`
+- **HiveMindOrchestrator**: `src/amplihack/agents/goal_seeking/hive_mind/orchestrator.py`
+- **Dataset**: `datasets/5000t-seed42-v1.0/` -- pre-built 5000-turn baseline DB

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # amplihack-agent-eval
 
-Evaluation framework for goal-seeking AI agents. Tests memory recall, tool use, planning, and reasoning across progressive difficulty levels (L1-L12).
+Evaluation framework for goal-seeking AI agents. Tests memory recall, tool use,
+planning, and reasoning across progressive difficulty levels (L1-L12).
 
 ## Key Features
 
@@ -10,6 +11,26 @@ Evaluation framework for goal-seeking AI agents. Tests memory recall, tool use, 
 - **Agent-agnostic** -- Works with any agent through the `AgentAdapter` interface
 - **Self-improvement loop** -- Automated EVAL -> ANALYZE -> PROPOSE -> CHALLENGE -> VOTE -> APPLY -> RE-EVAL cycle
 - **Multi-seed holdout** -- Run across multiple random seeds to measure inter-seed variance
+- **Hive mind evaluation** -- Multi-agent topology comparison (flat, distributed DHT, federated)
+
+## Running Evals
+
+| Guide | What It Covers |
+|-------|---------------|
+| **[Running Evals Quick Start](running-evals.md)** | All eval types on one page -- single-agent, 20-agent, and distributed |
+| [Long-Horizon Memory Eval](LONG_HORIZON_EVAL.md) | Single-agent eval: 15 question categories, grading system, dataset details |
+| [Hive Mind Eval Strategy](hive-mind-eval.md) | Multi-agent topologies, scoring methodology, four-layer architecture |
+| [Distributed Eval on Azure](azure-hive-qa-eval.md) | Deploy agents to Azure, feed content, run eval, cleanup |
+
+## Framework Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Architecture](architecture.md) | Package layout, core concepts, and design principles |
+| [Evaluation Levels](levels.md) | Complete guide to all 12 progressive difficulty levels (L1-L12) |
+| [Writing Adapters](adapters.md) | How to write custom `AgentAdapter` implementations |
+| [Self-Improvement Loop](self-improvement.md) | Automated improvement cycle with safety gates |
+| [Multi-Agent Eval](multi-agent-eval.md) | Multi-agent evaluation scenarios |
 
 ## Installation
 
@@ -84,16 +105,6 @@ amplihack-eval compare --seeds 42,123,456,789 --turns 100
 # Self-improvement loop
 amplihack-eval self-improve --iterations 5 --turns 100
 ```
-
-## Documentation
-
-| Guide | Description |
-|-------|-------------|
-| [Architecture](architecture.md) | Package layout, core concepts, and design principles |
-| [Evaluation Levels](levels.md) | Complete guide to all 12 progressive difficulty levels (L1-L12) |
-| [Writing Adapters](adapters.md) | How to write custom `AgentAdapter` implementations |
-| [Self-Improvement Loop](self-improvement.md) | Automated improvement cycle with safety gates |
-| [Multi-Agent Eval](multi-agent-eval.md) | Planned multi-agent evaluation scenarios |
 
 ## Environment Variables
 

--- a/docs/running-evals.md
+++ b/docs/running-evals.md
@@ -1,0 +1,162 @@
+# Running Evals -- Quick Start
+
+This page covers all evaluation types in the amplihack-agent-eval framework.
+Choose the eval type that matches your scenario.
+
+## Eval Types at a Glance
+
+| Eval Type | Agents | Infrastructure | Use Case |
+|-----------|--------|---------------|----------|
+| [Single-agent (local)](#single-agent-local) | 1 | None | Baseline memory recall testing |
+| [20-agent comparative (local)](#20-agent-comparative-local) | 20+1 | None | Multi-agent topology comparison with adversarial testing |
+| [Distributed (Azure)](#distributed-azure) | 5-1000+ | Azure Container Apps + Service Bus | Production-scale distributed eval |
+
+## Single-Agent (Local)
+
+Tests a single agent's memory system with up to 5000 dialogue turns and 200
+questions across 15 categories.
+
+### Quick Run
+
+```bash
+python -m amplihack.eval.long_horizon_memory \
+  --turns 300 --questions 50 \
+  --model claude-sonnet-4-6 \
+  --grader-model claude-haiku-4-5-20251001 \
+  --output-dir /tmp/eval-results
+```
+
+### Smoke Test (fast, cheap)
+
+```bash
+python -m amplihack.eval.long_horizon_memory \
+  --turns 100 --questions 20
+```
+
+### Full Stress Test
+
+```bash
+python -m amplihack.eval.long_horizon_memory \
+  --turns 5000 --questions 200 \
+  --grader-votes 5 --seed 42 \
+  --output-dir /tmp/eval-results
+```
+
+### Skip Learning (use pre-built dataset)
+
+```bash
+amplihack-eval run \
+  --adapter learning-agent \
+  --skip-learning \
+  --load-db datasets/5000t-seed42-v1.0/memory_db \
+  --turns 5000 --questions 100
+```
+
+**Details**: [Long-Horizon Memory Eval](LONG_HORIZON_EVAL.md)
+
+## 20-Agent Comparative (Local)
+
+Runs four conditions in a single script to compare topologies:
+
+1. **SINGLE_AGENT** -- One agent learns all turns (ceiling)
+2. **ISOLATED_20** -- 20 agents, no sharing
+3. **FLAT_SHARED_20** -- 20 agents, all facts bulk-loaded
+4. **HIVE_20** -- 20 agents with consensus hive + 1 adversarial agent
+
+```bash
+python experiments/hive_mind/run_20agent_eval.py
+```
+
+This runs from the amplihack repo (not amplihack-agent-eval). Ensure both
+packages are installed:
+
+```bash
+pip install -e /path/to/amplihack
+pip install -e /path/to/amplihack-agent-eval
+export ANTHROPIC_API_KEY=...
+```
+
+**Details**: [Hive Mind Eval Strategy](hive-mind-eval.md)
+
+## Distributed (Azure)
+
+Deploys agents to Azure Container Apps and evaluates via Service Bus.
+
+### Deploy, Feed, Eval, Cleanup
+
+```bash
+# 1. Deploy
+HIVE_AGENT_COUNT=100 HIVE_AGENTS_PER_APP=5 \
+HIVE_AGENT_MODEL=claude-sonnet-4-6 \
+bash deploy/azure_hive/deploy.sh
+
+# 2. Feed content
+SB_CONN=$(az servicebus namespace authorization-rule keys list \
+  -g hive-mind-rg --namespace-name <ns> \
+  --name RootManageSharedAccessKey \
+  --query primaryConnectionString -o tsv)
+
+AMPLIHACK_MEMORY_CONNECTION_STRING="$SB_CONN" \
+AMPLIHACK_TOPIC_NAME="hive-events" \
+python deploy/azure_hive/feed_content.py --turns 5000
+
+# 3. Run eval
+LA_ID=$(az monitor log-analytics workspace list -g hive-mind-rg \
+  --query "[0].customerId" -o tsv)
+
+python experiments/hive_mind/query_hive.py \
+  --ooda-eval --repeats 1 \
+  --connection-string "$SB_CONN" \
+  --workspace-id "$LA_ID" \
+  --topic hive-events \
+  --answer-wait 600 \
+  --output results.json
+
+# 4. Cleanup
+bash deploy/azure_hive/deploy.sh --cleanup
+```
+
+**Details**: [Running Distributed Eval on Azure](azure-hive-qa-eval.md)
+
+## Prerequisites (All Eval Types)
+
+```bash
+# Install packages
+pip install -e /path/to/amplihack
+pip install -e /path/to/amplihack-agent-eval
+
+# Set API key
+export ANTHROPIC_API_KEY=...
+
+# For distributed eval only:
+az login
+pip install azure-servicebus
+```
+
+## Environment Variables
+
+| Variable | Used By | Description |
+|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | All | API key for LLM calls |
+| `GRADER_MODEL` | Single-agent, 20-agent | Model for grading (default: `claude-sonnet-4-5-20250929`) |
+| `EVAL_MODEL` | Single-agent, 20-agent | Model for LearningAgent (default: `claude-sonnet-4-5-20250929`) |
+| `HIVE_AGENT_MODEL` | Distributed | Model for hive agents (default: `claude-sonnet-4-6`) |
+| `HIVE_AGENT_COUNT` | Distributed | Number of agents to deploy |
+| `OODA_ANSWER_WAIT` | Distributed | Seconds to wait for answers (default: `600`) |
+
+## Comparing Results
+
+### Multi-seed comparison (single-agent)
+
+```bash
+amplihack-eval compare --seeds 42,123,456,789 --turns 100 --questions 20
+```
+
+### Cross-topology comparison
+
+```bash
+python -m amplihack_eval.compare \
+  results/single/scores.json \
+  results/flat/scores.json \
+  results/distributed/scores.json
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,8 +47,14 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Architecture: architecture.md
-  - Evaluation Levels: levels.md
-  - Writing Adapters: adapters.md
-  - Self-Improvement Loop: self-improvement.md
-  - Multi-Agent Eval: multi-agent-eval.md
+  - Running Evals: running-evals.md
+  - Eval Guides:
+    - Long-Horizon Memory: LONG_HORIZON_EVAL.md
+    - Hive Mind Strategy: hive-mind-eval.md
+    - Distributed Eval on Azure: azure-hive-qa-eval.md
+  - Framework:
+    - Architecture: architecture.md
+    - Evaluation Levels: levels.md
+    - Writing Adapters: adapters.md
+    - Self-Improvement Loop: self-improvement.md
+    - Multi-Agent Eval: multi-agent-eval.md


### PR DESCRIPTION
## Summary

- Add `running-evals.md` quick-start page covering all 3 eval types
- Rewrite Azure distributed eval docs for current deploy/feed/eval flow
- Update hive mind architecture docs to four-layer design
- Remove all point-in-time results and stale baselines
- Reorganize mkdocs nav

## Test plan

- [ ] `mkdocs build` succeeds
- [ ] All commands in docs are copy-pasteable and reference correct paths
- [ ] No point-in-time data (dates, scores, results) in any doc

Generated with [Claude Code](https://claude.com/claude-code)