### PR TITLE
fix: remediate eval post-merge audit drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Evaluation framework for goal-seeking AI agents. Tests memory recall, tool use, 
 ## Installation
 
 ```bash
-# Basic installation (data generation and adapters, no LLM grading)
+# Basic installation (datasets, reports, HTTP/subprocess adapters; no LLM grading)
 pip install amplihack-agent-eval
 
 # With Anthropic grading support
@@ -33,6 +33,8 @@ pip install amplihack-agent-eval[dev]
 # Everything
 pip install amplihack-agent-eval[all,dev]
 ```
+
+`learning-agent`, `continuous`, and `python -m amplihack_eval.azure.eval_distributed` all import the sibling `amplihack` package. This repo does not declare that dependency directly because the main repo already depends on `amplihack-agent-eval`. Install a sibling checkout of `amplihack` when you need those surfaces.
 
 ## Quick Start
 
@@ -80,7 +82,7 @@ for cb in report.category_breakdown:
 # Run eval against an HTTP agent
 amplihack-eval run --turns 100 --questions 20 --adapter http --agent-url http://localhost:8000
 
-# Run eval with amplihack's LearningAgent
+# Run eval with amplihack's LearningAgent (requires sibling amplihack install)
 amplihack-eval run --turns 100 --questions 20 --adapter learning-agent
 
 # Multi-seed comparison

--- a/docs/LONG_HORIZON_EVAL.md
+++ b/docs/LONG_HORIZON_EVAL.md
@@ -390,7 +390,7 @@ amplihack-eval list-datasets
 # Download a pre-built dataset
 amplihack-eval download-dataset 5000t-seed42-v1.0
 
-# Run evaluation using the pre-built DB (skip learning phase)
+# Run evaluation using the pre-built DB (skip learning phase; requires sibling amplihack install)
 amplihack-eval run \
   --adapter learning-agent \
   --skip-learning \
@@ -412,7 +412,7 @@ for ds in datasets:
 # Download a dataset
 path = download_dataset("5000t-seed42-v1.0")
 
-# Use with evaluation
+# Use with evaluation (requires sibling amplihack install)
 from amplihack_eval.adapters.learning_agent import LearningAgentAdapter
 adapter = LearningAgentAdapter(storage_path=path / "memory_db")
 ```
@@ -434,7 +434,7 @@ to keep the repository lightweight.
 # Basic evaluation (100 turns, 20 questions)
 amplihack-eval run --turns 100 --questions 20 --adapter http --agent-url http://localhost:8000
 
-# With LearningAgent
+# With LearningAgent (requires sibling amplihack install)
 amplihack-eval run --turns 100 --adapter learning-agent --model claude-sonnet-4-6
 
 # Large-scale stress test

--- a/docs/azure-hive-qa-eval.md
+++ b/docs/azure-hive-qa-eval.md
@@ -13,6 +13,8 @@ export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
 ./run_distributed_eval.sh   --agents 100   --turns 5000   --questions 50   --question-set standard
 ```
 
+`AMPLIHACK_SOURCE_ROOT` is enough when the deployment source and runtime venv come from the same checkout. Set `AMPLIHACK_ROOT` separately only if the wrapper should use a different `amplihack/.venv`.
+
 Reuse an existing deployment:
 
 ```bash
@@ -20,6 +22,8 @@ SKIP_DEPLOY=1 HIVE_NAME=amplihive3175e HIVE_RESOURCE_GROUP=hive-pr3175-rg ./run_
 ```
 
 ## Direct Runner Command
+
+This path requires the sibling `amplihack` package to be installed because it reuses the main repo's long-horizon harness.
 
 ```bash
 python -m amplihack_eval.azure.eval_distributed   --connection-string "<event-hubs-connection-string>"   --input-hub "hive-events-amplihive3175e"   --response-hub "eval-responses-amplihive3175e"   --agents 100   --agents-per-app 5   --turns 5000   --questions 50   --question-set standard   --parallel-workers 1   --question-failover-retries 2   --answer-timeout 0   --output /tmp/eval_report.json

--- a/docs/distributed-hive-eval.md
+++ b/docs/distributed-hive-eval.md
@@ -14,7 +14,7 @@ Use this repo for the eval harness. Use the main `amplihack` repo when you need 
 - Azure CLI authenticated to the target subscription
 - Python environment with `amplihack-agent-eval` installed
 - access to the sibling `amplihack` repo
-- `ANTHROPIC_API_KEY` set for grading and the default learning-agent runtime
+- `ANTHROPIC_API_KEY` set for grading and for any learning-agent-based runs
 
 ## Fastest End-to-End Path
 
@@ -28,6 +28,8 @@ export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
 
 ./run_distributed_eval.sh   --agents 100   --turns 5000   --questions 50   --question-set standard
 ```
+
+If the runtime venv should come from the same checkout, `AMPLIHACK_SOURCE_ROOT` is enough. Set `AMPLIHACK_ROOT` separately only when you need the wrapper to use a different `amplihack/.venv`.
 
 This path:
 
@@ -54,7 +56,7 @@ export HIVE_RESOURCE_GROUP=hive-pr3175-rg
 
 ## Run the Distributed Runner Directly
 
-Use the Python module when you already know the Event Hubs connection string and hub names.
+Use the Python module when you already know the Event Hubs connection string and hub names. This direct path requires the sibling `amplihack` package to be installed because it reuses the main repo's long-horizon harness.
 
 ```bash
 python -m amplihack_eval.azure.eval_distributed   --connection-string "<event-hubs-connection-string>"   --input-hub "hive-events-amplihive3175e"   --response-hub "eval-responses-amplihive3175e"   --agents 100   --agents-per-app 5   --turns 5000   --questions 50   --seed 42   --question-set standard   --parallel-workers 1   --question-failover-retries 2   --answer-timeout 0   --output /tmp/eval_report.json
@@ -112,6 +114,8 @@ Set:
 ```bash
 export AMPLIHACK_SOURCE_ROOT=/path/to/amplihack
 ```
+
+If you need the wrapper to read code from one checkout but use the Python environment from another, set `AMPLIHACK_ROOT` as well. Otherwise the wrapper now defaults `AMPLIHACK_ROOT` from `AMPLIHACK_SOURCE_ROOT`.
 
 ### You want to run against an already live hive
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,19 +33,21 @@ Evaluation framework for goal-seeking AI agents. It generates long-horizon datas
 ## Installation
 
 ```bash
-# Basic installation (data generation and adapters, no LLM grading)
+# Basic installation (datasets, reports, HTTP/subprocess adapters; no LLM grading)
 pip install amplihack-agent-eval
 
 # Development install
 pip install -e ".[dev]"
 ```
 
+`learning-agent`, `continuous`, and `python -m amplihack_eval.azure.eval_distributed` all import the sibling `amplihack` package. This repo does not declare that dependency directly because the main repo already depends on `amplihack-agent-eval`. Install a sibling checkout of `amplihack` when you need those surfaces.
+
 ## Quick Start
 
 ### Run a local eval
 
 ```bash
-amplihack-eval run   --turns 100   --questions 20   --adapter learning-agent   --question-set standard   --output-dir /tmp/eval-run
+amplihack-eval run   --turns 100   --questions 20   --adapter http   --agent-url http://localhost:8000   --question-set standard   --output-dir /tmp/eval-run
 ```
 
 ### Compare seeds or question sets
@@ -64,9 +66,11 @@ python -m amplihack_eval.azure.eval_distributed   --connection-string "<event-hu
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `ANTHROPIC_API_KEY` | Required for grading and for the default learning-agent adapter | unset |
+| `ANTHROPIC_API_KEY` | Required for grading and for the learning-agent adapter | unset |
 | `GRADER_MODEL` | Model used for grading | `claude-sonnet-4-5-20250929` |
 | `EVAL_MODEL` | Model used by the learning-agent adapter | `claude-sonnet-4-5-20250929` |
+
+The package-level env defaults above are still the core runner defaults. The Azure distributed runner and `run_distributed_eval.sh` currently override the grader-model default to `claude-haiku-4-5-20251001` unless you pass `--grader-model` explicitly.
 
 ## Contributing
 
@@ -78,6 +82,8 @@ pytest tests/ -q
 ruff check src/ tests/
 ruff format --check src/ tests/
 ```
+
+Install a sibling checkout of `amplihack` as well if you want to exercise `learning-agent`, `continuous`, or the direct Azure distributed runner from this repo.
 
 ## License
 

--- a/docs/repeats-eval.md
+++ b/docs/repeats-eval.md
@@ -24,7 +24,7 @@ amplihack-eval compare \
   --output-dir /tmp/eval-compare
 ```
 
-For Azure distributed reruns, use the current Event Hubs runner or the wrapper script:
+For Azure distributed reruns, use the current Event Hubs runner or the wrapper script. The direct Python runner requires the sibling `amplihack` package to be installed.
 
 ```bash
 python -m amplihack_eval.azure.eval_distributed ...

--- a/docs/running-evals.md
+++ b/docs/running-evals.md
@@ -2,6 +2,8 @@
 
 This page is the command-oriented quick start for the current eval surface. Use it when you want to know which entrypoint to run.
 
+> Note: standalone `amplihack-agent-eval` installs cover HTTP/subprocess adapters, datasets, and report tooling. The `learning-agent` adapter, `continuous`, and `python -m amplihack_eval.azure.eval_distributed` import the sibling `amplihack` package.
+
 ## Choose an Entry Point
 
 | Goal | Command | When To Use |
@@ -14,6 +16,8 @@ This page is the command-oriented quick start for the current eval surface. Use 
 ## Local Runs
 
 ### LearningAgent adapter
+
+Requires the sibling `amplihack` package to be installed.
 
 ```bash
 amplihack-eval run   --turns 100   --questions 20   --adapter learning-agent   --question-set standard   --output-dir /tmp/eval-run
@@ -37,7 +41,7 @@ The distributed path uses **Event Hubs** for agent input and eval responses. The
 
 ### Direct runner
 
-Use this when the Azure hive is already deployed and you have the Event Hubs namespace connection string.
+Use this when the Azure hive is already deployed and you have the Event Hubs namespace connection string. This direct path also requires the sibling `amplihack` package because it reuses the main repo's long-horizon harness.
 
 ```bash
 python -m amplihack_eval.azure.eval_distributed   --connection-string "<event-hubs-connection-string>"   --input-hub "hive-events-amplihive3175e"   --response-hub "eval-responses-amplihive3175e"   --agents 100   --agents-per-app 5   --turns 5000   --questions 50   --question-set standard   --parallel-workers 1   --question-failover-retries 2   --answer-timeout 0   --output /tmp/eval_report.json
@@ -57,7 +61,7 @@ Reuse an existing deployment instead of redeploying:
 SKIP_DEPLOY=1 HIVE_NAME=amplihive3175e HIVE_RESOURCE_GROUP=hive-pr3175-rg ./run_distributed_eval.sh   --agents 100   --turns 5000   --questions 50   --question-set holdout
 ```
 
-The wrapper expects the sibling `amplihack` repo for Azure deployment assets. Set `AMPLIHACK_SOURCE_ROOT` if that repo is not checked out next to `amplihack-agent-eval`.
+The wrapper expects the sibling `amplihack` repo for Azure deployment assets. Set `AMPLIHACK_SOURCE_ROOT` if that repo is not checked out next to `amplihack-agent-eval`. The wrapper now uses `AMPLIHACK_SOURCE_ROOT` as the default `AMPLIHACK_ROOT` too; only set `AMPLIHACK_ROOT` separately if you want the Python venv to come from a different checkout.
 
 ## Question Sets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amplihack-agent-eval"
-version = "0.1.0"
+version = "0.1.1"
 description = "Evaluation framework for goal-seeking AI agents: memory recall, tool use, planning, reasoning"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/amplihack_eval/__init__.py
+++ b/src/amplihack_eval/__init__.py
@@ -33,7 +33,7 @@ Public API:
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from .adapters.base import AgentAdapter, AgentResponse, ToolCall
 from .adapters.hive_mind_adapter import HiveMindGroupAdapter, InMemorySharedStore

--- a/src/amplihack_eval/adapters/remote_agent_adapter.py
+++ b/src/amplihack_eval/adapters/remote_agent_adapter.py
@@ -655,7 +655,7 @@ class RemoteAgentAdapter:
             self._release_pending_answers_for_agent(
                 agent_id,
                 reason="agent restart",
-                detail=(f"duplicate AGENT_ONLINE with boot_id={boot_id or 'unknown'} " "while question was pending"),
+                detail=(f"duplicate AGENT_ONLINE with boot_id={boot_id or 'unknown'} while question was pending"),
             )
 
     def _handle_agent_shutdown(self, agent_id: str, reason: str = "", detail: str = "") -> None:

--- a/src/amplihack_eval/adapters/remote_agent_adapter.py
+++ b/src/amplihack_eval/adapters/remote_agent_adapter.py
@@ -23,6 +23,7 @@ Answers are collected from the eval-responses Event Hub, correlated by event_id.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -48,6 +49,7 @@ except ImportError:  # pragma: no cover
         name: str, *, tracer_name: str, attributes: Any = None
     ) -> Any:
         return _contextlib.nullcontext()
+
 
 logger = logging.getLogger(__name__)
 logging.getLogger("azure.eventhub").setLevel(logging.WARNING)
@@ -165,8 +167,7 @@ class RemoteAgentAdapter:
             self._run_id,
         )
         configure_otel(
-            service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip()
-            or "amplihack.azure-eval-harness",
+            service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip() or "amplihack.azure-eval-harness",
             component="remote-agent-adapter",
             attributes=self._span_attributes(),
         )
@@ -177,12 +178,14 @@ class RemoteAgentAdapter:
         try:
             return int(agent_id.rsplit("-", 1)[-1])
         except (ValueError, IndexError):
-            return abs(hash(agent_id))
+            digest = hashlib.sha256(agent_id.encode("utf-8")).digest()
+            return int.from_bytes(digest[:8], "big", signed=False)
 
     def _get_num_partitions(self) -> int:
         """Return the input hub partition count, caching the first result."""
         if self._num_partitions is not None:
             return self._num_partitions
+        consumer = None
         try:
             from azure.eventhub import EventHubConsumerClient  # type: ignore[import-unresolved]
 
@@ -192,9 +195,18 @@ class RemoteAgentAdapter:
                 eventhub_name=self._input_hub,
             )
             self._num_partitions = len(consumer.get_partition_ids())
-            consumer.close()
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "RemoteAgentAdapter: failed to query partition count for hub=%s; "
+                "falling back to 32 partitions (%s: %s)",
+                self._input_hub,
+                type(exc).__name__,
+                exc,
+            )
             self._num_partitions = 32
+        finally:
+            if consumer is not None:
+                consumer.close()
         return self._num_partitions
 
     def _target_partition(self, agent_id: str) -> str:
@@ -328,9 +340,7 @@ class RemoteAgentAdapter:
             while True:
                 with self._online_lock:
                     missing_agents = [
-                        f"agent-{i}"
-                        for i in range(self._agent_count)
-                        if f"agent-{i}" not in self._online_agents
+                        f"agent-{i}" for i in range(self._agent_count) if f"agent-{i}" not in self._online_agents
                     ]
                     online_count = self._agent_count - len(missing_agents)
 
@@ -476,9 +486,7 @@ class RemoteAgentAdapter:
                 if (self._replicate_learning_to_all_agents and learn_count >= 1) or (
                     not self._replicate_learning_to_all_agents and learn_count >= self._agent_count
                 ):
-                    expected_progress_agents = {
-                        self._agent_name(i) for i in range(self._agent_count)
-                    }
+                    expected_progress_agents = {self._agent_name(i) for i in range(self._agent_count)}
 
                 if expected_progress_agents is not None:
                     self._start_feed_telemetry_monitor(expected_progress_agents)
@@ -583,9 +591,7 @@ class RemoteAgentAdapter:
 
             return answer
 
-    def _release_pending_answers_for_agent(
-        self, agent_id: str, *, reason: str, detail: str = ""
-    ) -> None:
+    def _release_pending_answers_for_agent(self, agent_id: str, *, reason: str, detail: str = "") -> None:
         released_event_ids: list[str] = []
         with self._answer_lock:
             for event_id, target_name in list(self._answer_targets.items()):
@@ -649,10 +655,7 @@ class RemoteAgentAdapter:
             self._release_pending_answers_for_agent(
                 agent_id,
                 reason="agent restart",
-                detail=(
-                    f"duplicate AGENT_ONLINE with boot_id={boot_id or 'unknown'} "
-                    "while question was pending"
-                ),
+                detail=(f"duplicate AGENT_ONLINE with boot_id={boot_id or 'unknown'} " "while question was pending"),
             )
 
     def _handle_agent_shutdown(self, agent_id: str, reason: str = "", detail: str = "") -> None:
@@ -680,10 +683,7 @@ class RemoteAgentAdapter:
 
     def _question_attempt_targets(self, base_target_agent: int, max_attempts: int) -> list[int]:
         if max_attempts <= 1 or self._agents_per_app <= 1:
-            return [
-                (base_target_agent + attempt) % self._agent_count
-                for attempt in range(max_attempts)
-            ]
+            return [(base_target_agent + attempt) % self._agent_count for attempt in range(max_attempts)]
 
         app_groups = [
             list(range(start, min(start + self._agents_per_app, self._agent_count)))
@@ -727,9 +727,7 @@ class RemoteAgentAdapter:
     def _dispatch_question_targets(self, base_target_agent: int, max_attempts: int) -> list[int]:
         ordered_candidates = self._question_attempt_targets(base_target_agent, self._agent_count)
         eligible_candidates = [
-            candidate
-            for candidate in ordered_candidates
-            if self._is_question_target_eligible(candidate)
+            candidate for candidate in ordered_candidates if self._is_question_target_eligible(candidate)
         ]
         if eligible_candidates:
             skipped = len(ordered_candidates) - len(eligible_candidates)
@@ -816,11 +814,7 @@ class RemoteAgentAdapter:
             tracer_name=__name__,
             attributes=self._span_attributes(
                 question_length=len(question),
-                target_agent=(
-                    self._agent_name(target_agent)
-                    if target_agent is not None
-                    else "auto-round-robin"
-                ),
+                target_agent=(self._agent_name(target_agent) if target_agent is not None else "auto-round-robin"),
             ),
         ):
             if self._learn_count > 0 and not self._idle_wait_done.is_set():
@@ -903,9 +897,7 @@ class RemoteAgentAdapter:
             while True:
                 with self._ready_lock:
                     missing_agents = [
-                        f"agent-{i}"
-                        for i in range(self._agent_count)
-                        if f"agent-{i}" not in self._ready_agents
+                        f"agent-{i}" for i in range(self._agent_count) if f"agent-{i}" not in self._ready_agents
                     ]
                     ready_count = self._agent_count - len(missing_agents)
                 if ready_count >= self._agent_count:

--- a/src/amplihack_eval/azure/eval_distributed.py
+++ b/src/amplihack_eval/azure/eval_distributed.py
@@ -31,6 +31,7 @@ from pathlib import Path
 try:
     from amplihack.observability import configure_otel, start_span
 except ImportError:  # pragma: no cover
+
     def configure_otel(  # type: ignore[misc]
         service_name: str, *, component: str = "", attributes: object = None
     ) -> bool:
@@ -40,6 +41,7 @@ except ImportError:  # pragma: no cover
         name: str, *, tracer_name: str, attributes: object = None
     ) -> object:
         return contextlib.nullcontext()
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -97,16 +99,12 @@ def main() -> int:
     p = argparse.ArgumentParser(
         description="Distributed eval — same harness as single-agent, remote agents via Event Hubs"
     )
-    p.add_argument(
-        "--connection-string", required=True, help="Event Hubs namespace connection string"
-    )
+    p.add_argument("--connection-string", required=True, help="Event Hubs namespace connection string")
     p.add_argument("--input-hub", default="hive-events", help="Agent input Event Hub name")
     p.add_argument("--response-hub", default="eval-responses", help="Eval response Event Hub name")
     p.add_argument("--turns", type=int, default=300, help="Dialogue turns")
     p.add_argument("--questions", type=int, default=50, help="Number of questions")
-    p.add_argument(
-        "--agents", type=int, default=_default_agent_count(), help="Number of deployed agents"
-    )
+    p.add_argument("--agents", type=int, default=_default_agent_count(), help="Number of deployed agents")
     p.add_argument(
         "--agents-per-app",
         type=int,
@@ -120,16 +118,17 @@ def main() -> int:
         default="standard",
         help="Deterministic question subset to use",
     )
-    p.add_argument("--grader-model", default="claude-haiku-4-5-20251001")
+    p.add_argument(
+        "--grader-model",
+        default="claude-haiku-4-5-20251001",
+        help="Grading model override for this Azure distributed runner (default: claude-haiku-4-5-20251001)",
+    )
     p.add_argument("--resource-group", default="", help="Azure resource group (optional, unused)")
     p.add_argument(
         "--answer-timeout",
         type=int,
         default=None,
-        help=(
-            "Seconds to wait per answer before failover "
-            "(default: scale-aware; 0 for 100+ agents, 120 otherwise)"
-        ),
+        help=("Seconds to wait per answer before failover " "(default: scale-aware; 0 for 100+ agents, 120 otherwise)"),
     )
     p.add_argument("--output", default="", help="Output JSON path")
     p.add_argument(
@@ -150,7 +149,7 @@ def main() -> int:
         default=None,
         help=(
             "Number of failover retries for unanswered questions "
-            "(default: scale-aware; 0 up to 49 agents, 1 for 50-99, 2 for 100+)"
+            "(default: scale-aware; 1 up to 49 agents, 1 for 50-99, 2 for 100+)"
         ),
     )
     args = p.parse_args()
@@ -163,8 +162,7 @@ def main() -> int:
     args.agents_per_app = max(1, min(args.agents, args.agents_per_app))
 
     configure_otel(
-        service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip()
-        or "amplihack.azure-eval-harness",
+        service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip() or "amplihack.azure-eval-harness",
         component="eval-distributed",
         attributes={
             "amplihack.agent_count": args.agents,
@@ -178,7 +176,16 @@ def main() -> int:
         },
     )
 
-    from amplihack.eval.long_horizon_memory import LongHorizonMemoryEval, _print_report
+    try:
+        from amplihack.eval.long_horizon_memory import LongHorizonMemoryEval, _print_report
+    except ImportError as exc:
+        print(
+            "Error: python -m amplihack_eval.azure.eval_distributed requires the sibling "
+            "amplihack package to be installed because it reuses amplihack's long-horizon harness.",
+            file=sys.stderr,
+        )
+        print(f"Detail: {exc}", file=sys.stderr)
+        return 1
 
     from amplihack_eval.adapters.remote_agent_adapter import RemoteAgentAdapter
 

--- a/src/amplihack_eval/azure/eval_distributed.py
+++ b/src/amplihack_eval/azure/eval_distributed.py
@@ -128,7 +128,7 @@ def main() -> int:
         "--answer-timeout",
         type=int,
         default=None,
-        help=("Seconds to wait per answer before failover " "(default: scale-aware; 0 for 100+ agents, 120 otherwise)"),
+        help=("Seconds to wait per answer before failover (default: scale-aware; 0 for 100+ agents, 120 otherwise)"),
     )
     p.add_argument("--output", default="", help="Output JSON path")
     p.add_argument(

--- a/src/amplihack_eval/azure/eval_distributed_security.py
+++ b/src/amplihack_eval/azure/eval_distributed_security.py
@@ -26,6 +26,7 @@ from pathlib import Path
 try:
     from amplihack.observability import configure_otel, start_span
 except ImportError:  # pragma: no cover
+
     def configure_otel(  # type: ignore[misc]
         service_name: str, *, component: str = "", attributes: object = None
     ) -> bool:
@@ -35,6 +36,7 @@ except ImportError:  # pragma: no cover
         name: str, *, tracer_name: str, attributes: object = None
     ) -> object:
         return contextlib.nullcontext()
+
 
 # Suppress EH noise
 for name in ["azure", "azure.eventhub", "azure.eventhub._pyamqp", "uamqp"]:
@@ -75,8 +77,7 @@ def main() -> int:
     args = p.parse_args()
 
     configure_otel(
-        service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip()
-        or "amplihack.azure-eval-harness",
+        service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip() or "amplihack.azure-eval-harness",
         component="eval-distributed-security",
         attributes={
             "amplihack.agent_count": args.agents,

--- a/src/amplihack_eval/azure/eval_monitor.py
+++ b/src/amplihack_eval/azure/eval_monitor.py
@@ -226,9 +226,7 @@ class EvalMonitor:
                     "progress_count": s.progress_count,
                     "answer_count": s.answer_count,
                     "phases_seen": list(s.phases_seen),
-                    "last_event_age_s": round(time.time() - s.last_event_ts, 1)
-                    if s.last_event_ts
-                    else None,
+                    "last_event_age_s": round(time.time() - s.last_event_ts, 1) if s.last_event_ts else None,
                 }
                 for agent_id, s in self._agents.items()
             }
@@ -269,9 +267,7 @@ class EvalMonitor:
 
     def _status_counts(self) -> dict[str, int]:
         snapshot = self._snapshot()
-        progress_agents = sum(
-            1 for agent in snapshot["agents"].values() if int(agent["progress_count"]) > 0
-        )
+        progress_agents = sum(1 for agent in snapshot["agents"].values() if int(agent["progress_count"]) > 0)
         return {
             "online": int(snapshot["agents_online"]),
             "ready": int(snapshot["agents_ready"]),

--- a/src/amplihack_eval/azure/eval_retrieval_smoke.py
+++ b/src/amplihack_eval/azure/eval_retrieval_smoke.py
@@ -20,6 +20,7 @@ from pathlib import Path
 try:
     from amplihack.observability import configure_otel, start_span
 except ImportError:  # pragma: no cover
+
     def configure_otel(  # type: ignore[misc]
         service_name: str, *, component: str = "", attributes: object = None
     ) -> bool:
@@ -29,6 +30,7 @@ except ImportError:  # pragma: no cover
         name: str, *, tracer_name: str, attributes: object = None
     ) -> object:
         return contextlib.nullcontext()
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -96,17 +98,11 @@ def answer_contains_expected(answer: str, expected_codename: str) -> bool:
 
 
 def main() -> int:
-    p = argparse.ArgumentParser(
-        description="Focused distributed retrieval smoke against Azure hive agents"
-    )
-    p.add_argument(
-        "--connection-string", required=True, help="Event Hubs namespace connection string"
-    )
+    p = argparse.ArgumentParser(description="Focused distributed retrieval smoke against Azure hive agents")
+    p.add_argument("--connection-string", required=True, help="Event Hubs namespace connection string")
     p.add_argument("--input-hub", default="hive-events", help="Agent input Event Hub name")
     p.add_argument("--response-hub", default="eval-responses", help="Eval response Event Hub name")
-    p.add_argument(
-        "--agents", type=int, default=_default_agent_count(), help="Number of deployed agents"
-    )
+    p.add_argument("--agents", type=int, default=_default_agent_count(), help="Number of deployed agents")
     p.add_argument("--resource-group", default="", help="Azure resource group (optional)")
     p.add_argument("--answer-timeout", type=int, default=120, help="Seconds to wait per answer")
     p.add_argument(
@@ -119,8 +115,7 @@ def main() -> int:
     args = p.parse_args()
 
     configure_otel(
-        service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip()
-        or "amplihack.azure-retrieval-smoke",
+        service_name=os.environ.get("OTEL_SERVICE_NAME", "").strip() or "amplihack.azure-retrieval-smoke",
         component="eval-retrieval-smoke",
         attributes={
             "amplihack.agent_count": args.agents,

--- a/src/amplihack_eval/cli.py
+++ b/src/amplihack_eval/cli.py
@@ -27,6 +27,7 @@ import sys
 from pathlib import Path
 
 QUESTION_SET_CHOICES = ("standard", "holdout")
+CONTINUOUS_CONDITION_CHOICES = ("single", "flat", "federated")
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
@@ -234,6 +235,7 @@ def _cmd_download_dataset(args: argparse.Namespace) -> int:
         path = download_dataset(name, output_dir=output_dir, force=force)
         print(f"Dataset downloaded to: {path}")
         print("\nTo use it:")
+        print("  # LearningAgentAdapter requires the sibling amplihack package to be installed")
         print("  amplihack-eval run --adapter learning-agent --skip-learning \\")
         print(f"    --load-db {path}/memory_db --turns 5000 --questions 100")
         return 0
@@ -285,20 +287,46 @@ def _cmd_continuous(args: argparse.Namespace) -> int:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    conditions = [c.strip() for c in args.conditions.split(",")]
+    conditions = [c.strip() for c in args.conditions.split(",") if c.strip()]
+    conditions = list(dict.fromkeys(conditions))
+    if not conditions:
+        print(
+            "Error: --conditions cannot be empty. Expected a comma-separated subset of: "
+            + ", ".join(CONTINUOUS_CONDITION_CHOICES)
+        )
+        return 1
 
-    report = run_continuous_eval(
-        num_turns=args.turns,
-        num_questions=args.questions,
-        num_agents=args.agents,
-        num_groups=args.groups,
-        seed=args.seed,
-        model=getattr(args, "model", ""),
-        parallel_workers=getattr(args, "parallel_workers", 5),
-        prompt_variant=getattr(args, "prompt_variant", None),
-        conditions=conditions,
-        repeats=getattr(args, "repeats", 3),
-    )
+    invalid_conditions = [c for c in conditions if c not in CONTINUOUS_CONDITION_CHOICES]
+    if invalid_conditions:
+        print(
+            "Invalid --conditions value(s): "
+            + ", ".join(invalid_conditions)
+            + ". Expected a comma-separated subset of: "
+            + ", ".join(CONTINUOUS_CONDITION_CHOICES)
+        )
+        return 1
+
+    try:
+        report = run_continuous_eval(
+            num_turns=args.turns,
+            num_questions=args.questions,
+            num_agents=args.agents,
+            num_groups=args.groups,
+            seed=args.seed,
+            model=getattr(args, "model", ""),
+            parallel_workers=getattr(args, "parallel_workers", 5),
+            prompt_variant=getattr(args, "prompt_variant", None),
+            conditions=conditions,
+            repeats=getattr(args, "repeats", 3),
+        )
+    except ImportError as exc:
+        print(
+            "Error: amplihack-eval continuous requires the sibling amplihack package "
+            "to be installed because it exercises the goal-seeking runtime.",
+            file=sys.stderr,
+        )
+        print(f"Detail: {exc}", file=sys.stderr)
+        return 1
 
     print_continuous_report(report)
 
@@ -316,18 +344,22 @@ def _create_adapter(args: argparse.Namespace):
     load_db = getattr(args, "load_db", "")
 
     if adapter_type == "learning-agent":
-        from .adapters.learning_agent import LearningAgentAdapter
+        try:
+            from .adapters.learning_agent import LearningAgentAdapter
 
-        storage_path = load_db if load_db else "/tmp/eval_memory_db"
-        prompt_variant = getattr(args, "prompt_variant", None)
-        kwargs = {}
-        if prompt_variant is not None:
-            kwargs["prompt_variant"] = prompt_variant
-        return LearningAgentAdapter(
-            model=getattr(args, "model", ""),
-            storage_path=storage_path,
-            **kwargs,
-        )
+            storage_path = load_db if load_db else "/tmp/eval_memory_db"
+            prompt_variant = getattr(args, "prompt_variant", None)
+            kwargs = {}
+            if prompt_variant is not None:
+                kwargs["prompt_variant"] = prompt_variant
+            return LearningAgentAdapter(
+                model=getattr(args, "model", ""),
+                storage_path=storage_path,
+                **kwargs,
+            )
+        except ImportError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return None
 
     elif adapter_type == "subprocess":
         from .adapters.subprocess_adapter import SubprocessAdapter
@@ -396,7 +428,7 @@ def main() -> None:
         "--adapter",
         choices=["http", "subprocess", "learning-agent", "distributed-hive"],
         default="http",
-        help="Agent adapter type",
+        help="Agent adapter type (learning-agent requires the sibling amplihack package)",
     )
     run_parser.add_argument("--agent-url", default="http://localhost:8000", help="Agent HTTP URL")
     run_parser.add_argument("--agent-command", default="", help="Agent subprocess command")
@@ -454,7 +486,7 @@ def main() -> None:
         "--adapter",
         choices=["http", "subprocess", "learning-agent"],
         default="http",
-        help="Agent adapter type",
+        help="Agent adapter type (learning-agent requires the sibling amplihack package)",
     )
     cmp_parser.add_argument("--agent-url", default="http://localhost:8000", help="Agent HTTP URL")
     cmp_parser.add_argument("--agent-command", default="", help="Agent subprocess command")
@@ -486,7 +518,7 @@ def main() -> None:
         "--adapter",
         choices=["http", "subprocess", "learning-agent"],
         default="http",
-        help="Agent adapter type",
+        help="Agent adapter type (learning-agent requires the sibling amplihack package)",
     )
     si_parser.add_argument("--agent-url", default="http://localhost:8000", help="Agent HTTP URL")
     si_parser.add_argument("--agent-command", default="", help="Agent subprocess command")
@@ -532,13 +564,13 @@ def main() -> None:
     cont_parser.add_argument(
         "--conditions",
         default="single,flat,federated",
-        help="Comma-separated conditions to run (default: single,flat,federated)",
+        help="Comma-separated subset of single,flat,federated (default: single,flat,federated)",
     )
     cont_parser.add_argument(
         "--parallel-workers",
         type=int,
         default=5,
-        help="Parallel workers for Q&A grading (default: 5)",
+        help="Parallel workers for Q&A grading (default: 5, max 20)",
     )
     cont_parser.add_argument(
         "--repeats",

--- a/src/amplihack_eval/core/continuous_eval.py
+++ b/src/amplihack_eval/core/continuous_eval.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from ..adapters.base import AgentAdapter, AgentResponse
-from ..core.runner import EvalReport, EvalRunner
+from ..core.runner import MAX_PARALLEL_WORKERS, EvalReport, EvalRunner
 from ..data.security_analyst_scenario import (
     generate_dialogue,
     generate_questions,
@@ -195,7 +195,7 @@ class _MultiAgentAdapter(AgentAdapter):
         self._model = model
         self._turn_idx = 0
         self._turn_lock = threading.Lock()
-        self._parallel_workers = parallel_workers
+        self._parallel_workers = max(1, min(MAX_PARALLEL_WORKERS, parallel_workers))
         self._hive_store = hive_store
         self._agent_map: dict[str, Any] = {getattr(a, "agent_name", f"agent_{i}"): a for i, a in enumerate(agents)}
 
@@ -657,7 +657,7 @@ def _run_federated(
     try:
         from amplihack.agents.goal_seeking.hive_mind.distributed_hive_graph import (
             DistributedHiveGraph,
-        )  # type: ignore[import-untyped]
+        )
 
         shared_hive = DistributedHiveGraph(
             "federated-hive",

--- a/tests/test_continuous_eval.py
+++ b/tests/test_continuous_eval.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+import amplihack_eval.core.continuous_eval as continuous_eval
+from amplihack_eval.cli import _cmd_continuous
+from amplihack_eval.core.continuous_eval import _MultiAgentAdapter
+from amplihack_eval.core.runner import MAX_PARALLEL_WORKERS
+
+
+class TestContinuousEvalValidation:
+    def test_cmd_continuous_rejects_empty_conditions(self, tmp_path, capsys):
+        args = Namespace(
+            verbose=False,
+            output_dir=str(tmp_path),
+            conditions="   ",
+            turns=10,
+            questions=5,
+            agents=2,
+            groups=1,
+            seed=42,
+            model="",
+            parallel_workers=5,
+            prompt_variant=None,
+            repeats=1,
+        )
+
+        exit_code = _cmd_continuous(args)
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert "--conditions cannot be empty" in captured.out
+
+    def test_cmd_continuous_rejects_unknown_conditions(self, tmp_path, capsys):
+        args = Namespace(
+            verbose=False,
+            output_dir=str(tmp_path),
+            conditions="single,unknown",
+            turns=10,
+            questions=5,
+            agents=2,
+            groups=1,
+            seed=42,
+            model="",
+            parallel_workers=5,
+            prompt_variant=None,
+            repeats=1,
+        )
+
+        exit_code = _cmd_continuous(args)
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert "Invalid --conditions value" in captured.out
+
+    def test_cmd_continuous_reports_missing_amplihack_dependency(self, tmp_path, capsys, monkeypatch):
+        args = Namespace(
+            verbose=False,
+            output_dir=str(tmp_path),
+            conditions="single",
+            turns=10,
+            questions=5,
+            agents=2,
+            groups=1,
+            seed=42,
+            model="",
+            parallel_workers=5,
+            prompt_variant=None,
+            repeats=1,
+        )
+
+        def _raise_import_error(**kwargs):
+            raise ImportError("No module named 'amplihack'")
+
+        monkeypatch.setattr(continuous_eval, "run_continuous_eval", _raise_import_error)
+
+        exit_code = _cmd_continuous(args)
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert "requires the sibling amplihack package" in captured.err
+
+
+class TestMultiAgentAdapterWorkerClamp:
+    def test_parallel_workers_clamped_to_minimum(self):
+        adapter = _MultiAgentAdapter([object()], model="", parallel_workers=0)
+        assert adapter._parallel_workers == 1
+
+    def test_parallel_workers_clamped_to_maximum(self):
+        adapter = _MultiAgentAdapter([object()], model="", parallel_workers=100)
+        assert adapter._parallel_workers == MAX_PARALLEL_WORKERS

--- a/tests/test_eval_distributed.py
+++ b/tests/test_eval_distributed.py
@@ -1,6 +1,38 @@
 """Tests for scale-aware distributed eval defaults."""
 
+import builtins
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from amplihack_eval.adapters import remote_agent_adapter
 from amplihack_eval.azure import eval_distributed
+
+
+def _install_fake_long_horizon(monkeypatch, fake_report, fake_run):
+    module = types.ModuleType("amplihack.eval.long_horizon_memory")
+
+    class FakeLongHorizonMemoryEval:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def run(self, adapter, grader_model=""):
+            return fake_run(self, adapter, grader_model=grader_model)
+
+    module.LongHorizonMemoryEval = FakeLongHorizonMemoryEval
+    module._print_report = lambda report: None
+
+    eval_package = types.ModuleType("amplihack.eval")
+    eval_package.long_horizon_memory = module
+    amplihack_package = types.ModuleType("amplihack")
+    amplihack_package.eval = eval_package
+
+    monkeypatch.setitem(sys.modules, "amplihack", amplihack_package)
+    monkeypatch.setitem(sys.modules, "amplihack.eval", eval_package)
+    monkeypatch.setitem(sys.modules, "amplihack.eval.long_horizon_memory", module)
 
 
 class TestScaleAwareDefaults:
@@ -27,3 +59,78 @@ class TestScaleAwareDefaults:
         assert eval_distributed._default_answer_timeout(10) == 120
         assert eval_distributed._default_answer_timeout(50) == 120
         assert eval_distributed._default_answer_timeout(100) == 0
+
+    def test_help_text_matches_small_cluster_failover_default(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["eval_distributed", "--help"])
+
+        with pytest.raises(SystemExit):
+            eval_distributed.main()
+
+        captured = capsys.readouterr()
+        assert "1 up to 49 agents" in captured.out
+        assert "1 for 50-99" in captured.out
+        assert "2 for 100+" in captured.out
+
+    def test_main_accepts_question_set_and_writes_report(self, monkeypatch, tmp_path):
+        output_path = tmp_path / "eval_report.json"
+        fake_report = MagicMock()
+        fake_report.to_dict.return_value = {"overall_score": 1.0}
+
+        class FakeAdapter:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def close(self):
+                return None
+
+        def fake_run(self, adapter, grader_model=""):
+            return fake_report
+
+        _install_fake_long_horizon(monkeypatch, fake_report, fake_run)
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "eval_distributed",
+                "--connection-string",
+                "Endpoint=sb://example/;SharedAccessKeyName=test;SharedAccessKey=value",
+                "--input-hub",
+                "hive-events-test",
+                "--response-hub",
+                "eval-responses-test",
+                "--question-set",
+                "holdout",
+                "--output",
+                str(output_path),
+            ],
+        )
+        monkeypatch.setattr(remote_agent_adapter, "RemoteAgentAdapter", FakeAdapter)
+
+        assert eval_distributed.main() == 0
+
+        report = json.loads(output_path.read_text())
+        assert report["question_set"] == "holdout"
+
+    def test_main_reports_missing_amplihack_dependency(self, monkeypatch, capsys):
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "amplihack.eval.long_horizon_memory":
+                raise ImportError("No module named 'amplihack'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "eval_distributed",
+                "--connection-string",
+                "Endpoint=sb://example/;SharedAccessKeyName=test;SharedAccessKey=value",
+            ],
+        )
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        assert eval_distributed.main() == 1
+        captured = capsys.readouterr()
+        assert "requires the sibling amplihack package" in captured.err

--- a/tests/test_eval_monitor.py
+++ b/tests/test_eval_monitor.py
@@ -171,8 +171,7 @@ class TestEvalMonitor:
 
         partition_context.update_checkpoint.assert_called_once_with(event)
         assert any(
-            "Skipping malformed eval monitor event on partition 5" in record.message
-            for record in caplog.records
+            "Skipping malformed eval monitor event on partition 5" in record.message for record in caplog.records
         )
 
     def test_consume_event_logs_handler_failure_and_checkpoints(self, caplog):
@@ -197,8 +196,7 @@ class TestEvalMonitor:
 
         partition_context.update_checkpoint.assert_called_once_with(event)
         assert any(
-            "Failed to process eval monitor event_type=AGENT_ONLINE agent_id=agent-7"
-            in record.message
+            "Failed to process eval monitor event_type=AGENT_ONLINE agent_id=agent-7" in record.message
             for record in caplog.records
         )
 

--- a/tests/test_eval_monitor.py
+++ b/tests/test_eval_monitor.py
@@ -5,12 +5,21 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 
 def _load_module():
     mod = importlib.import_module("amplihack_eval.azure.eval_monitor")
     return importlib.reload(mod)
+
+
+def _patch_azure_eventhub(*, consumer_cls):
+    azure_pkg = types.ModuleType("azure")
+    eventhub_mod = types.ModuleType("azure.eventhub")
+    eventhub_mod.EventHubConsumerClient = consumer_cls
+    azure_pkg.eventhub = eventhub_mod
+    return patch.dict(sys.modules, {"azure": azure_pkg, "azure.eventhub": eventhub_mod})
 
 
 class TestEvalMonitor:
@@ -45,9 +54,10 @@ class TestEvalMonitor:
         )
         fake_consumer = MagicMock()
         fake_thread = MagicMock()
+        consumer_cls = MagicMock()
 
         with (
-            patch("azure.eventhub.EventHubConsumerClient", create=True) as consumer_cls,
+            _patch_azure_eventhub(consumer_cls=consumer_cls),
             patch.object(mod.threading, "Thread", return_value=fake_thread),
         ):
             consumer_cls.from_connection_string.return_value = fake_consumer

--- a/tests/test_quality_audit.py
+++ b/tests/test_quality_audit.py
@@ -10,6 +10,7 @@ import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from amplihack_eval.adapters.base import AgentAdapter, AgentResponse
 from amplihack_eval.adapters.hive_mind_adapter import (
     MAX_SHARED_CONTEXT_FACTS,

--- a/tests/test_quality_audit.py
+++ b/tests/test_quality_audit.py
@@ -10,7 +10,6 @@ import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from amplihack_eval.adapters.base import AgentAdapter, AgentResponse
 from amplihack_eval.adapters.hive_mind_adapter import (
     MAX_SHARED_CONTEXT_FACTS,
@@ -67,12 +66,25 @@ class TestLearningAgentAdapterNoSilentFallbacks:
 
     def test_learn_raises_on_failure(self):
         """learn() must raise RuntimeError when the underlying agent fails."""
-        # We cannot import LearningAgentAdapter without the amplihack package,
-        # so we test the pattern via the mock path.
-        with pytest.raises(ImportError):
+        mock_agent = MagicMock()
+        mock_agent.learn_from_content.side_effect = ValueError("learn boom")
+        mock_agent_cls = MagicMock(return_value=mock_agent)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "amplihack": MagicMock(),
+                "amplihack.agents": MagicMock(),
+                "amplihack.agents.goal_seeking": MagicMock(),
+                "amplihack.agents.goal_seeking.learning_agent": MagicMock(LearningAgent=mock_agent_cls),
+            },
+        ):
             from amplihack_eval.adapters.learning_agent import LearningAgentAdapter
 
-            LearningAgentAdapter()
+            adapter = LearningAgentAdapter(model="test-model", storage_path="/tmp/test")
+
+        with pytest.raises(RuntimeError, match="LearningAgent failed to learn content: learn boom"):
+            adapter.learn("content")
 
 
 # ===========================================================================

--- a/tests/test_remote_agent_adapter.py
+++ b/tests/test_remote_agent_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sys
@@ -143,6 +144,31 @@ class TestRemoteAgentAdapterInit:
         create_runtime.assert_called_once()
         assert create_runtime.call_args.kwargs["runtime_kind"] == "goal"
         assert create_runtime.call_args.kwargs["bind_answer_mode"] is False
+
+
+class TestPartitionRoutingHelpers:
+    def test_non_numeric_agent_name_uses_stable_hash(self):
+        mod = _load_module()
+        expected = int.from_bytes(hashlib.sha256(b"coordinator").digest()[:8], "big")
+        assert mod.RemoteAgentAdapter._agent_index("coordinator") == expected
+
+    def test_empty_agent_name_uses_stable_hash(self):
+        mod = _load_module()
+        expected = int.from_bytes(hashlib.sha256(b"").digest()[:8], "big")
+        assert mod.RemoteAgentAdapter._agent_index("") == expected
+
+    def test_partition_count_fallback_logs_warning(self):
+        mod = _load_module()
+        adapter = _make_adapter(mod)
+        adapter._num_partitions = None
+
+        with (
+            patch.dict("sys.modules", {"azure.eventhub": None}),
+            patch.object(mod.logger, "warning") as warning,
+        ):
+            assert adapter._get_num_partitions() == 32
+
+        warning.assert_called_once()
 
 
 class TestPublishEvent:
@@ -312,9 +338,7 @@ class TestLearnFromContent:
             "agent-2",
         ]
         assert adapter._learn_turn_counts == [2, 2, 2]
-        adapter._start_feed_telemetry_monitor.assert_called_once_with(
-            {"agent-0", "agent-1", "agent-2"}
-        )
+        adapter._start_feed_telemetry_monitor.assert_called_once_with({"agent-0", "agent-1", "agent-2"})
         assert adapter._feed_telemetry_wait_done.is_set()
 
     def test_replicated_learning_targets_all_agents(self):
@@ -369,9 +393,7 @@ class TestLearnFromContent:
         assert adapter._learn_turn_counts == [1, 1, 1]
         assert result["facts_stored"] == 2
         assert result["replicated_to"] == 3
-        adapter._start_feed_telemetry_monitor.assert_called_once_with(
-            {"agent-0", "agent-1", "agent-2"}
-        )
+        adapter._start_feed_telemetry_monitor.assert_called_once_with({"agent-0", "agent-1", "agent-2"})
         assert adapter._feed_telemetry_wait_done.is_set()
 
     def test_learn_increments_counter(self):
@@ -596,9 +618,7 @@ class TestAnswerQuestion:
         adapter = _make_adapter(mod, agent_count=15)
         adapter._idle_wait_done.set()
         adapter._agents_per_app = 5
-        adapter._ready_agents.update(
-            {"agent-0", "agent-1", "agent-2", "agent-3", "agent-4"}
-        )
+        adapter._ready_agents.update({"agent-0", "agent-1", "agent-2", "agent-3", "agent-4"})
         adapter._question_ineligible_agents.add("agent-4")
 
         with patch.object(
@@ -740,9 +760,7 @@ class TestOnEvent:
                 if agent_id:
                     with adapter._progress_lock:
                         adapter._progress_agents.add(agent_id)
-                        adapter._progress_counts[agent_id] = int(
-                            data.get("processed_count", 0) or 0
-                        )
+                        adapter._progress_counts[agent_id] = int(data.get("processed_count", 0) or 0)
 
         on_event(MagicMock(), mock_event)
         assert "agent-1" in adapter._progress_agents

--- a/tests/test_remote_agent_adapter.py
+++ b/tests/test_remote_agent_adapter.py
@@ -19,6 +19,19 @@ def _load_module():
     return importlib.reload(mod)
 
 
+def _patch_azure_eventhub(*, consumer_cls=None, producer_cls=None, event_data_cls=None):
+    azure_pkg = types.ModuleType("azure")
+    eventhub_mod = types.ModuleType("azure.eventhub")
+    if consumer_cls is not None:
+        eventhub_mod.EventHubConsumerClient = consumer_cls
+    if producer_cls is not None:
+        eventhub_mod.EventHubProducerClient = producer_cls
+    if event_data_cls is not None:
+        eventhub_mod.EventData = event_data_cls
+    azure_pkg.eventhub = eventhub_mod
+    return patch.dict(sys.modules, {"azure": azure_pkg, "azure.eventhub": eventhub_mod})
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -179,19 +192,14 @@ class TestPublishEvent:
         mock_producer = MagicMock()
         mock_batch = MagicMock()
         mock_producer.create_batch.return_value = mock_batch
+        producer_cls = MagicMock()
+        event_data_cls = MagicMock()
 
         with (
-            patch(
-                "azure.eventhub.EventHubProducerClient",
-                create=True,
-            ) as MockProducer,
-            patch(
-                "azure.eventhub.EventData",
-                create=True,
-            ) as MockEventData,
+            _patch_azure_eventhub(producer_cls=producer_cls, event_data_cls=event_data_cls),
         ):
-            MockProducer.from_connection_string.return_value = mock_producer
-            MockEventData.side_effect = lambda data: data
+            producer_cls.from_connection_string.return_value = mock_producer
+            event_data_cls.side_effect = lambda data: data
 
             payload = {"event_type": "LEARN_CONTENT", "event_id": "abc"}
             adapter._publish_event(payload, partition_key="agent-0")
@@ -206,24 +214,19 @@ class TestPublishEvent:
         mock_producer = MagicMock()
         mock_batch = MagicMock()
         mock_producer.create_batch.return_value = mock_batch
+        producer_cls = MagicMock()
+        event_data_cls = MagicMock()
 
         with (
-            patch(
-                "azure.eventhub.EventHubProducerClient",
-                create=True,
-            ) as MockProducer,
-            patch(
-                "azure.eventhub.EventData",
-                create=True,
-            ) as MockEventData,
+            _patch_azure_eventhub(producer_cls=producer_cls, event_data_cls=event_data_cls),
         ):
-            MockProducer.from_connection_string.return_value = mock_producer
-            MockEventData.side_effect = lambda data: data
+            producer_cls.from_connection_string.return_value = mock_producer
+            event_data_cls.side_effect = lambda data: data
 
             adapter._publish_event({"event_type": "LEARN_CONTENT", "event_id": "abc"}, "agent-0")
             adapter._publish_event({"event_type": "LEARN_CONTENT", "event_id": "def"}, "agent-1")
 
-        assert MockProducer.from_connection_string.call_count == 1
+        assert producer_cls.from_connection_string.call_count == 1
         assert mock_producer.send_batch.call_count == 2
 
     def test_publish_retries_on_failure(self):
@@ -238,22 +241,17 @@ class TestPublishEvent:
         mock_producer_ok = MagicMock()
         mock_batch = MagicMock()
         mock_producer_ok.create_batch.return_value = mock_batch
+        producer_cls = MagicMock()
+        event_data_cls = MagicMock()
 
         with (
-            patch(
-                "azure.eventhub.EventHubProducerClient",
-                create=True,
-            ) as MockProducer,
-            patch(
-                "azure.eventhub.EventData",
-                create=True,
-            ) as MockEventData,
+            _patch_azure_eventhub(producer_cls=producer_cls, event_data_cls=event_data_cls),
         ):
-            MockProducer.from_connection_string.side_effect = [
+            producer_cls.from_connection_string.side_effect = [
                 mock_producer_fail,
                 mock_producer_ok,
             ]
-            MockEventData.side_effect = lambda data: data
+            event_data_cls.side_effect = lambda data: data
 
             adapter._publish_event(
                 {"event_type": "INPUT", "event_id": "x"},
@@ -271,21 +269,17 @@ class TestPublishEvent:
             p.create_batch.return_value = MagicMock()
             return p
 
+        producer_cls = MagicMock()
+        event_data_cls = MagicMock()
+
         with (
-            patch(
-                "azure.eventhub.EventHubProducerClient",
-                create=True,
-            ) as MockProducer,
-            patch(
-                "azure.eventhub.EventData",
-                create=True,
-            ) as MockEventData,
+            _patch_azure_eventhub(producer_cls=producer_cls, event_data_cls=event_data_cls),
         ):
-            MockProducer.from_connection_string.side_effect = [
+            producer_cls.from_connection_string.side_effect = [
                 make_failing_producer(),
                 make_failing_producer(),
             ]
-            MockEventData.side_effect = lambda data: data
+            event_data_cls.side_effect = lambda data: data
 
             with pytest.raises(ConnectionError):
                 adapter._publish_event(
@@ -918,8 +912,9 @@ class TestListenerStartup:
             adapter._shutdown.set()
 
         consumer.receive.side_effect = fake_receive
+        consumer_cls = MagicMock()
 
-        with patch("azure.eventhub.EventHubConsumerClient", create=True) as consumer_cls:
+        with _patch_azure_eventhub(consumer_cls=consumer_cls):
             consumer_cls.from_connection_string.return_value = consumer
             adapter._listen_for_answers()
 
@@ -950,8 +945,9 @@ class TestListenerStartup:
 
         first_consumer.receive.side_effect = receive_first
         second_consumer.receive.side_effect = receive_second
+        consumer_cls = MagicMock()
 
-        with patch("azure.eventhub.EventHubConsumerClient", create=True) as consumer_cls:
+        with _patch_azure_eventhub(consumer_cls=consumer_cls):
             consumer_cls.from_connection_string.side_effect = [first_consumer, second_consumer]
             adapter._listen_for_answers()
 
@@ -981,8 +977,9 @@ class TestListenerStartup:
 
         first_consumer.receive.side_effect = receive_first
         second_consumer.receive.side_effect = receive_second
+        consumer_cls = MagicMock()
 
-        with patch("azure.eventhub.EventHubConsumerClient", create=True) as consumer_cls:
+        with _patch_azure_eventhub(consumer_cls=consumer_cls):
             consumer_cls.from_connection_string.side_effect = [first_consumer, second_consumer]
             adapter._listen_for_answers()
 


### PR DESCRIPTION
## Summary
- remediate eval-side post-merge audit drift on clean branch `feat/issue-45-eval-audit-remediation`
- harden distributed/continuous CLI validation and sibling-package error messaging
- refresh eval docs so local/distributed runner behavior matches the actual current surface
- add regression coverage for distributed defaults, remote adapter behavior, continuous-condition validation, and zero-Azure-SDK CI execution
- apply the repo-format and inherited CI-red follow-ups currently required for this branch and the latest `main`

## Validated commit
- `f68ad0bb7435a9b392caf7169d6574d6fce2f7d5` (`feat/issue-45-eval-audit-remediation`)

## Validation
- `PYTHONPATH=src:/home/azureuser/src/amplihack/worktrees/issue-3455-memory-eval-audit-remediation/src python -m pytest tests/ -q --tb=short` → `457 passed, 1 skipped`
- changed-file `pre-commit` run on touched tests → passed
- `python -m ruff format --check src/ tests/` → passed after formatter follow-up on this branch
- `PYTHONPATH=src:/home/azureuser/src/amplihack/worktrees/issue-3455-memory-eval-audit-remediation/src python -m amplihack_eval.azure.eval_distributed --help` → passed
- `PYTHONPATH=src python -c 'import amplihack_eval; print(amplihack_eval.__version__)'` → `0.1.1`

## QA-team outside-in evidence
- scenario: `/home/azureuser/.copilot/session-state/1082e81f-3c63-4794-aca5-eaf559a04aef/files/gadugi/scenarios/eval-distributed-surfaces.yaml`
- validate: `/home/azureuser/.npm/_npx/df47e1e015eb4832/node_modules/.bin/gadugi-test validate -f .../eval-distributed-surfaces.yaml` → passed on 2026-03-23
- run: `/home/azureuser/.npm/_npx/df47e1e015eb4832/node_modules/.bin/gadugi-test run -d /tmp/gadugi-eval-scenarios` → passed on 2026-03-23
- outside-in checks covered:
  - `python -m amplihack_eval.cli run --help` exposes question-set, distributed-hive adapter, and parallel-workers
  - `python -m amplihack_eval.azure.eval_distributed --help` exposes Event Hubs wording, grader-model override help, and question failover controls
  - `python -m amplihack_eval.cli continuous --conditions '   '` now fails with the explicit empty-conditions error
  - `python -m amplihack_eval.cli continuous --conditions invalid` now fails with the explicit invalid-conditions error
- evidence log: `/home/azureuser/.copilot/session-state/1082e81f-3c63-4794-aca5-eaf559a04aef/files/gadugi/results/eval-run.log`

## Quality audit summary
- quality-audit recipe path was blocked in this Copilot CLI environment by the `unknown option '--system-prompt'` failure tracked in `#3397`, so the audit was executed with a manual fallback loop using SEEK → multi-reviewer validation → FIX.
- audit cycles converged on the eval-side issues now re-ported here: clearer distributed help, explicit grader-model override help, stricter `continuous --conditions` validation, bounded parallel-worker behavior, and docs that correctly describe the sibling-`amplihack` requirement.
- a clean-branch code review found one final residual issue after the re-port (`--conditions ''` accepted and ran zero conditions); that was fixed here before final validation.
- after the formatter fix, full CI-equivalent local tests exposed two inherited branch/mainline problems: tests patching `azure.eventhub...` by import path without the Azure SDK installed, and a stale quality-audit test that still expected `LearningAgentAdapter` import to fail rather than asserting the actual no-silent-fallback contract. Both follow-ups are included here and validated locally.
- final state: no blocking findings remained in the clean-branch diff review, the full local test suite was green, and the outside-in scenarios above passed.

## Docs
- `README.md`
- `docs/index.md`
- `docs/running-evals.md`
- `docs/distributed-hive-eval.md`
- `docs/azure-hive-qa-eval.md`
- `docs/LONG_HORIZON_EVAL.md`
- `docs/repeats-eval.md`

## Remaining merge gate
- CI must be green before merge

Closes #45.

