### PR TITLE
feat(recipes): relocate eval recipes to canonical eval repo (#284)

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,56 @@
+# Eval Recipes
+
+Canonical home for the eval recipes. Previously these lived in
+`rysweet/amplihack` and `rysweet/amplihack-rs` (`amplifier-bundle/recipes/`)
+which made the recipes co-tenant with non-eval code and forced the main
+amplihack Python package to keep its `amplihack.eval.*` modules around.
+
+## Recipes
+
+- **`domain-agent-eval.yaml`** — Evaluates the 5 domain agents
+  (CodeReview, MeetingSynthesizer, DocumentCreator, DataAnalysis, ProjectPlanning)
+  on their L1–L4 scenarios plus a teaching-session evaluation, then writes
+  combined scores.
+
+- **`long-horizon-memory-eval.yaml`** — 1000-turn memory stress test with
+  a self-improvement loop (eval → analyze → diagnose → fix → re-eval).
+
+## Running
+
+```bash
+amplihack recipe run recipes/domain-agent-eval.yaml \
+  -c repo_path="."
+
+amplihack recipe run recipes/long-horizon-memory-eval.yaml \
+  -c num_turns="1000" \
+  -c repo_path="."
+```
+
+## Dependencies — current state
+
+Both recipes are partially ported to the `amplihack_eval` package shipped
+with this repo:
+
+| Recipe symbol                                | Status     | Source                                       |
+| -------------------------------------------- | ---------- | -------------------------------------------- |
+| `amplihack_eval.data.long_horizon`           | ✅ here    | `src/amplihack_eval/data/long_horizon.py`    |
+| `amplihack_eval.data.progressive_levels`     | ✅ here    | `src/amplihack_eval/data/progressive_levels.py` |
+| `amplihack.eval.run_domain_evals`            | ⏳ upstream | needs port from `rysweet/amplihack` |
+| `amplihack.eval.teaching_session`            | ⏳ upstream | needs port from `rysweet/amplihack` |
+| `amplihack.eval.teaching_eval`               | ⏳ upstream | needs port from `rysweet/amplihack` |
+| `amplihack.eval.progressive_test_suite`      | ⏳ upstream | needs port from `rysweet/amplihack` |
+| `amplihack.eval.long_horizon_memory`         | ⏳ upstream | needs port from `rysweet/amplihack` |
+| `amplihack.eval.long_horizon_self_improve`   | ⏳ upstream | needs port from `rysweet/amplihack` |
+
+The upstream-pending modules also depend on `amplihack.agents.domain_agents.*`
+and `amplihack.llm`, so a full port requires either bringing those packages
+into this repo as a sub-dependency or factoring out a shared agent-runtime
+crate. Tracked as separate porting issues.
+
+## Migration history
+
+Recipes relocated to this repo on 2026-04-22 in response to
+`rysweet/amplihack-rs#284`. The original copies in
+`rysweet/amplihack/amplifier-bundle/recipes/` and
+`rysweet/amplihack-rs/amplifier-bundle/recipes/` are removed in favor of
+this canonical location.

--- a/recipes/domain-agent-eval.yaml
+++ b/recipes/domain-agent-eval.yaml
@@ -1,0 +1,267 @@
+name: "domain-agent-eval"
+description: "Evaluate all 5 domain agents: DomainEvalHarness + teaching evaluation + combined scores"
+version: "1.0.0"
+author: "Amplihack Team"
+tags:
+  ["eval", "domain-agents", "teaching", "code-review", "meeting", "document", "data", "planning"]
+
+# DOMAIN AGENT EVAL RECIPE
+#
+# Evaluates all 5 domain-specific agents:
+#   - CodeReviewAgent: Code quality analysis
+#   - MeetingSynthesizerAgent: Meeting notes summarization
+#   - DocumentCreatorAgent: Document generation
+#   - DataAnalysisAgent: Data analysis and insights
+#   - ProjectPlanningAgent: Project planning and estimation
+#
+# Steps:
+#   1. Run DomainEvalHarness on each agent (L1-L4 scenarios)
+#   2. Run teaching evaluation (teacher-student knowledge transfer)
+#   3. Generate combined scores (domain + teaching weighted)
+#   4. Document results with per-agent breakdown
+#
+# Each domain agent provides its own eval levels (L1-L4):
+#   - L1: Basic task execution
+#   - L2: Complex multi-step tasks
+#   - L3: Edge cases and error handling
+#   - L4: Integration and cross-domain tasks
+#
+# Philosophy:
+#   - Domain agents are first-class citizens with their own eval
+#   - Teaching ability is a key differentiator
+#   - Combined scoring gives holistic view
+#   - Per-agent profiles enable targeted improvement
+#
+# Usage:
+#   amplifier recipes execute domain-agent-eval.yaml --context '{
+#     "agents": "code_review meeting_synthesizer document_creator data_analysis project_planning",
+#     "output_dir": "./domain_eval_results"
+#   }'
+#
+# CLI equivalent:
+#   PYTHONPATH=src python -m amplihack.eval.run_domain_evals
+
+recursion:
+  max_depth: 4
+  max_total_steps: 25
+
+context:
+  # Space-separated list of agents to evaluate (or "all" for all 5)
+  agents: "code_review meeting_synthesizer document_creator data_analysis project_planning"
+
+  # Output directory for results
+  output_dir: "./domain_eval_results"
+
+  # SDK for teaching evaluation
+  sdk: "mini"
+
+  # Internal state
+  domain_eval_results: ""
+  teaching_eval_results: ""
+  combined_scores: ""
+  documentation: ""
+
+steps:
+  # ==========================================================================
+  # STEP 1: RUN DOMAIN EVAL HARNESS
+  # Run DomainEvalHarness on each specified agent.
+  # Each agent provides its own L1-L4 eval levels.
+  # ==========================================================================
+  - id: "run-domain-evals"
+    type: "bash"
+    command: |
+      echo "=== Step 1: Running Domain Agent Evaluations ==="
+      echo "Agents: {{agents}}"
+      echo "Output: {{output_dir}}"
+      echo ""
+
+      AGENT_ARGS=""
+      if [ "{{agents}}" != "all" ]; then
+        AGENT_ARGS="--agents {{agents}}"
+      fi
+
+      PYTHONPATH=src python -m amplihack.eval.run_domain_evals \
+        $AGENT_ARGS \
+        --output-dir "{{output_dir}}" \
+        2>&1
+
+      echo ""
+      echo "=== Domain Evals Complete ==="
+
+      if [ -f "{{output_dir}}/all_domain_evals.json" ]; then
+        cat "{{output_dir}}/all_domain_evals.json"
+      else
+        echo '{"error": "all_domain_evals.json not found"}'
+      fi
+    output: "domain_eval_results"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 2: RUN TEACHING EVALUATION
+  # Test each agent's ability to teach its domain knowledge to a student.
+  # Uses TeachingSession with domain-specific knowledge bases.
+  # ==========================================================================
+  - id: "run-teaching-eval"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 2: Teaching Evaluation
+
+      **Domain Eval Results:** {{domain_eval_results}}
+      **Agents:** {{agents}}
+      **SDK:** {{sdk}}
+
+      ## Your Task
+
+      For each domain agent that was evaluated, assess its teaching ability:
+
+      1. **Knowledge Base Extraction**: Can the agent articulate its domain knowledge?
+      2. **Explanation Quality**: Does it explain concepts clearly?
+      3. **Scaffolding**: Does it build understanding progressively?
+      4. **Self-Explanation**: Can it explain its own reasoning? (Chi 1994 principle)
+      5. **Verification**: Can it check if the student understood?
+
+      Run the teaching evaluation using the TeachingSession framework:
+
+      ```python
+      from amplihack.eval.teaching_session import TeachingSession, TeachingConfig
+      from amplihack.eval.teaching_eval import evaluate_teaching
+
+      for agent_name in agents:
+          config = TeachingConfig(
+              agent_name=f"teaching_{agent_name}",
+              max_turns=4,
+              sdk="{{sdk}}",
+          )
+          session = TeachingSession(config)
+          # Use agent's domain knowledge as the knowledge base
+          result = session.run(knowledge_base=agent.get_domain_knowledge())
+          teaching_score = evaluate_teaching(result)
+      ```
+
+      **Output as JSON:**
+      ```json
+      {
+        "teaching_scores": {
+          "code_review": {
+            "knowledge_articulation": 0.0,
+            "explanation_quality": 0.0,
+            "scaffolding": 0.0,
+            "self_explanation": 0.0,
+            "verification": 0.0,
+            "overall": 0.0
+          }
+        },
+        "best_teacher": "agent with highest teaching score",
+        "teaching_patterns": ["what makes good teaching agents"],
+        "improvement_areas": ["where teaching could improve"]
+      }
+      ```
+    output: "teaching_eval_results"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 3: GENERATE COMBINED SCORES
+  # Combine domain eval scores with teaching scores for holistic assessment.
+  # ==========================================================================
+  - id: "generate-combined-scores"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 3: Generate Combined Scores
+
+      **Domain Eval Results:** {{domain_eval_results}}
+      **Teaching Eval Results:** {{teaching_eval_results}}
+
+      ## Your Task
+
+      Generate combined scores for each agent using weighted formula:
+
+      **Combined Score = 0.7 * Domain Score + 0.3 * Teaching Score**
+
+      Rationale: Domain competence is the primary measure (70%), but teaching
+      ability indicates deeper understanding and is a valuable differentiator (30%).
+
+      For each agent, produce:
+      1. **Domain Score**: Average across L1-L4 levels
+      2. **Teaching Score**: Average across 5 teaching dimensions
+      3. **Combined Score**: Weighted combination
+      4. **Profile**: Strengths, weaknesses, recommended use cases
+      5. **Ranking**: Overall ranking across all agents
+
+      **Output as JSON:**
+      ```json
+      {
+        "agent_scores": {
+          "code_review": {
+            "domain_score": 0.0,
+            "teaching_score": 0.0,
+            "combined_score": 0.0,
+            "per_level": {"L1": 0.0, "L2": 0.0, "L3": 0.0, "L4": 0.0},
+            "strengths": ["..."],
+            "weaknesses": ["..."],
+            "recommended_use": "..."
+          }
+        },
+        "ranking": [
+          {"rank": 1, "agent": "...", "combined_score": 0.0}
+        ],
+        "overall_average": 0.0,
+        "fleet_health": "healthy|needs_attention|critical"
+      }
+      ```
+    output: "combined_scores"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 4: DOCUMENT RESULTS
+  # Create comprehensive evaluation report.
+  # ==========================================================================
+  - id: "document-results"
+    type: "bash"
+    parse_json: true
+    command: |
+      echo "=== Step 4: Documenting Results ==="
+
+      mkdir -p "{{output_dir}}"
+      REPORT_FILE="{{output_dir}}/domain_eval_report_$(date +%Y%m%d).md"
+
+      cat > "$REPORT_FILE" << 'REPORT_EOF'
+      # Domain Agent Evaluation Report
+
+      **Date:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+      **Agents Evaluated:** {{agents}}
+
+      ## Domain Eval Results
+      {{domain_eval_results}}
+
+      ## Teaching Eval Results
+      {{teaching_eval_results}}
+
+      ## Combined Scores
+      {{combined_scores}}
+
+      ---
+      Generated by domain-agent-eval recipe v1.0.0
+      REPORT_EOF
+
+      echo "Report saved to: $REPORT_FILE"
+
+      cat << EOF
+      {
+        "workflow": "domain-agent-eval",
+        "version": "1.0.0",
+        "agents_evaluated": "{{agents}}",
+        "status": "complete",
+        "steps_completed": 4,
+        "steps": [
+          "1. Run DomainEvalHarness",
+          "2. Run Teaching Evaluation",
+          "3. Generate Combined Scores",
+          "4. Document Results"
+        ],
+        "outputs": {
+          "domain_evals": "{{output_dir}}/all_domain_evals.json",
+          "report": "$REPORT_FILE"
+        }
+      }
+      EOF
+    output: "final_result"

--- a/recipes/long-horizon-memory-eval.yaml
+++ b/recipes/long-horizon-memory-eval.yaml
@@ -1,0 +1,423 @@
+name: "long-horizon-memory-eval"
+description: "1000-turn memory stress test with self-improvement loop: eval -> analyze -> diagnose -> fix -> re-eval"
+version: "2.0.0"
+author: "Amplihack Team"
+tags: ["eval", "memory", "long-horizon", "stress-test", "1000-turn"]
+
+# LONG-HORIZON MEMORY EVAL RECIPE
+#
+# Runs the 1000-turn memory stress test to evaluate agent memory at scale.
+#
+# The test generates a deterministic dialogue across multiple topic domains,
+# feeds turns to the agent one at a time, then asks questions that require
+# recall from various points in the conversation history.
+#
+# Steps:
+#   1. Generate dialogue data (deterministic, reproducible)
+#   2. Feed turns to agent (via learning phase)
+#   3. Generate and ask questions (spanning different recency/topics)
+#   4. Score answers (LLM-graded on 5 dimensions)
+#   5. Document findings (breakdown by category and recency)
+#
+# Philosophy:
+#   - Short-horizon eval is necessary but not sufficient
+#   - Real agents must handle 100s-1000s of turns
+#   - Memory decay patterns reveal system architecture limits
+#   - Reproducible data enables meaningful comparison across runs
+#
+# Usage:
+#   amplifier recipes execute long-horizon-memory-eval.yaml --context '{
+#     "num_turns": "1000",
+#     "num_questions": "100",
+#     "sdk": "mini"
+#   }'
+#
+# CLI equivalent:
+#   python -m amplihack.eval.long_horizon_memory --turns 1000 --questions 100
+#
+# Self-improvement loop:
+#   python -m amplihack.eval.long_horizon_self_improve --turns 100 --questions 20
+#
+# Multi-agent variant:
+#   python -m amplihack.eval.long_horizon_self_improve --turns 100 --questions 20 --multi-agent
+
+recursion:
+  max_depth: 4
+  max_total_steps: 20
+
+context:
+  # Number of dialogue turns to generate and feed
+  num_turns: "1000"
+
+  # Number of questions to generate and ask
+  num_questions: "100"
+
+  # SDK to use for the agent
+  sdk: "mini"
+
+  # Output directory for results
+  output_dir: "./eval_results/long_horizon"
+
+  # Agent name for memory isolation
+  agent_name: "long-horizon-agent"
+
+  # Seed for reproducible data generation
+  seed: "42"
+
+  # Self-improvement loop settings
+  self_improve: "false"
+  max_iterations: "3"
+  failure_threshold: "0.7"
+  use_multi_agent: "false"
+
+  # Internal state
+  dialogue_data: ""
+  feeding_result: ""
+  question_results: ""
+  score_report: ""
+  analysis: ""
+  self_improve_result: ""
+
+steps:
+  # ==========================================================================
+  # STEP 1: GENERATE DIALOGUE DATA
+  # Create deterministic dialogue turns across multiple topic domains.
+  # ==========================================================================
+  - id: "generate-dialogue"
+    type: "bash"
+    command: |
+      echo "=== Step 1: Generating Dialogue Data ==="
+      echo "Turns: {{num_turns}}"
+      echo "Seed: {{seed}}"
+      echo ""
+
+      PYTHONPATH=src python -c "
+      import json
+      from amplihack_eval.data.long_horizon import generate_dialogue
+
+      dialogue = generate_dialogue(num_turns=int('{{num_turns}}'), seed=int('{{seed}}'))
+
+      # Save full dialogue
+      import os
+      os.makedirs('{{output_dir}}', exist_ok=True)
+      with open('{{output_dir}}/dialogue.json', 'w') as f:
+          turns_data = [
+              {
+                  'turn_id': t.turn_id,
+                  'speaker': t.speaker,
+                  'content': t.content,
+                  'topic': t.topic,
+                  'subtopic': t.subtopic,
+                  'turn_number': t.turn_number,
+              }
+              for t in dialogue
+          ]
+          json.dump(turns_data, f, indent=2)
+
+      print(json.dumps({
+          'num_turns': len(dialogue),
+          'topics': list(set(t.topic for t in dialogue)),
+          'dialogue_file': '{{output_dir}}/dialogue.json'
+      }))
+      " 2>&1
+
+      echo ""
+      echo "=== Dialogue Generation Complete ==="
+    output: "dialogue_data"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 2: FEED TURNS TO AGENT
+  # Feed dialogue turns to the agent through its learning interface.
+  # This simulates a real conversation unfolding over time.
+  # ==========================================================================
+  - id: "feed-turns"
+    type: "bash"
+    command: |
+      echo "=== Step 2: Feeding Turns to Agent ==="
+      echo "Agent: {{agent_name}}"
+      echo "SDK: {{sdk}}"
+      echo "Turns: {{num_turns}}"
+      echo ""
+
+      PYTHONPATH=src python -c "
+      import json
+      import time
+
+      start = time.time()
+
+      # Load dialogue
+      with open('{{output_dir}}/dialogue.json') as f:
+          turns = json.load(f)
+
+      print(f'Loaded {len(turns)} turns')
+
+      # Convert to article format for learning subprocess
+      from amplihack_eval.data.progressive_levels import TestArticle
+      from amplihack.eval.progressive_test_suite import run_learning_subprocess
+
+      # Batch turns into chunks of 50 for efficiency
+      batch_size = 50
+      total_batches = (len(turns) + batch_size - 1) // batch_size
+      errors = 0
+
+      for batch_idx in range(total_batches):
+          batch_start = batch_idx * batch_size
+          batch_end = min(batch_start + batch_size, len(turns))
+          batch = turns[batch_start:batch_end]
+
+          # Convert batch to articles
+          articles = []
+          for turn in batch:
+              articles.append(TestArticle(
+                  title=f\"Turn {turn['turn_number']}: {turn['topic']} - {turn['subtopic']}\",
+                  content=f\"{turn['speaker']}: {turn['content']}\",
+                  url=f\"dialogue://turn/{turn['turn_number']}\",
+                  published=f\"2026-01-01T{turn['turn_number']:06d}Z\",
+                  metadata={'topic': turn['topic'], 'subtopic': turn['subtopic']},
+              ))
+
+          agent_name = '{{agent_name}}_$(date +%s)'
+          success, data = run_learning_subprocess(articles, agent_name, sdk={{sdk}})
+
+          if not success:
+              errors += 1
+              if errors > 5:
+                  break
+
+          if (batch_idx + 1) % 10 == 0:
+              elapsed = time.time() - start
+              print(f'  Batch {batch_idx + 1}/{total_batches} ({batch_end} turns, {elapsed:.1f}s)')
+
+      elapsed = time.time() - start
+      print(json.dumps({
+          'turns_fed': len(turns),
+          'batches': total_batches,
+          'errors': errors,
+          'duration_seconds': round(elapsed, 1)
+      }))
+      " 2>&1
+
+      echo ""
+      echo "=== Turn Feeding Complete ==="
+    output: "feeding_result"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 3: GENERATE AND ASK QUESTIONS
+  # Generate questions spanning different recency windows and topics,
+  # then ask them to the agent.
+  # ==========================================================================
+  - id: "generate-and-ask"
+    type: "bash"
+    command: |
+      echo "=== Step 3: Generating and Asking Questions ==="
+      echo "Questions: {{num_questions}}"
+      echo ""
+
+      PYTHONPATH=src python -c "
+      import json
+
+      from amplihack_eval.data.long_horizon import generate_dialogue, generate_questions
+
+      # Regenerate dialogue (deterministic with same seed)
+      dialogue = generate_dialogue(num_turns=int('{{num_turns}}'), seed=int('{{seed}}'))
+      questions = generate_questions(dialogue, num_questions=int('{{num_questions}}'), seed=int('{{seed}}'))
+
+      # Save questions
+      import os
+      os.makedirs('{{output_dir}}', exist_ok=True)
+      with open('{{output_dir}}/questions.json', 'w') as f:
+          q_data = [
+              {
+                  'question_id': q.question_id,
+                  'question_text': q.question_text,
+                  'category': q.category,
+                  'expected_answer': q.expected_answer,
+                  'source_turn': q.source_turn,
+              }
+              for q in questions
+          ]
+          json.dump(q_data, f, indent=2)
+
+      print(json.dumps({
+          'num_questions': len(questions),
+          'categories': list(set(q.category for q in questions)),
+          'questions_file': '{{output_dir}}/questions.json'
+      }))
+      " 2>&1
+
+      echo ""
+      echo "=== Question Generation Complete ==="
+    output: "question_results"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 4: SCORE AND ANALYZE
+  # Grade answers and compute per-category breakdowns.
+  # ==========================================================================
+  - id: "score-and-analyze"
+    type: "bash"
+    command: |
+      echo "=== Step 4: Scoring and Analyzing ==="
+
+      PYTHONPATH=src python -m amplihack.eval.long_horizon_memory \
+        --turns {{num_turns}} \
+        --questions {{num_questions}} \
+        --sdk {{sdk}} \
+        --output-dir "{{output_dir}}" \
+        --agent-name "{{agent_name}}" \
+        --seed {{seed}} \
+        2>&1
+
+      echo ""
+      echo "=== Scoring Complete ==="
+
+      if [ -f "{{output_dir}}/eval_report.json" ]; then
+        cat "{{output_dir}}/eval_report.json"
+      else
+        echo '{"status": "report not found"}'
+      fi
+    output: "score_report"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 5: DOCUMENT FINDINGS
+  # Generate a comprehensive report with memory decay analysis.
+  # ==========================================================================
+  - id: "document-findings"
+    agent: "amplihack:architect"
+    prompt: |
+      # Step 5: Document Long-Horizon Memory Findings
+
+      **Dialogue Data:** {{dialogue_data}}
+      **Feeding Result:** {{feeding_result}}
+      **Question Results:** {{question_results}}
+      **Score Report:** {{score_report}}
+
+      ## Your Task
+
+      Analyze the long-horizon memory test results and document findings.
+
+      **Analysis Dimensions:**
+
+      1. **Memory Decay Curve**
+         - How do scores change with turn recency?
+         - Is there a sharp cliff or gradual decay?
+         - What is the effective memory window?
+
+      2. **Category Performance**
+         - Which topic categories are remembered best?
+         - Are there systematic gaps in certain domains?
+
+      3. **Dimension Breakdown**
+         - Accuracy: Are recalled facts correct?
+         - Completeness: Are all relevant facts included?
+         - Specificity: Are details precise or vague?
+         - Relevance: Are retrieved facts on-topic?
+         - Coherence: Is the answer well-structured?
+
+      4. **Architecture Implications**
+         - What does performance reveal about memory architecture?
+         - Where are the bottlenecks?
+         - What changes would improve long-horizon performance?
+
+      Save the analysis to {{output_dir}}/long_horizon_analysis.md.
+
+      **Output as JSON:**
+      ```json
+      {
+        "overall_score": 0.0,
+        "memory_decay": {
+          "recent_100_turns": 0.0,
+          "mid_500_turns": 0.0,
+          "old_1000_turns": 0.0,
+          "decay_pattern": "gradual|cliff|none"
+        },
+        "category_scores": {},
+        "dimension_scores": {},
+        "key_findings": ["..."],
+        "architecture_implications": ["..."],
+        "recommendations": ["..."],
+        "report_file": "{{output_dir}}/long_horizon_analysis.md"
+      }
+      ```
+    output: "analysis"
+    parse_json: true
+
+  # ==========================================================================
+  # STEP 6: SELF-IMPROVEMENT LOOP (optional)
+  # Run iterative improvement: eval -> analyze -> diagnose -> fix -> re-eval
+  # ==========================================================================
+  - id: "self-improve"
+    type: "bash"
+    condition: "self_improve == 'true'"
+    command: |
+      echo "=== Step 6: Self-Improvement Loop ==="
+      echo "Max iterations: {{max_iterations}}"
+      echo "Failure threshold: {{failure_threshold}}"
+      echo "Multi-agent: {{use_multi_agent}}"
+      echo ""
+
+      MULTI_AGENT_FLAG=""
+      if [ "{{use_multi_agent}}" = "true" ]; then
+        MULTI_AGENT_FLAG="--multi-agent"
+      fi
+
+      PYTHONPATH=src python -m amplihack.eval.long_horizon_self_improve \
+        --turns {{num_turns}} \
+        --questions {{num_questions}} \
+        --iterations {{max_iterations}} \
+        --threshold {{failure_threshold}} \
+        --output-dir "{{output_dir}}/self_improve" \
+        --seed {{seed}} \
+        $MULTI_AGENT_FLAG \
+        2>&1
+
+      echo ""
+      echo "=== Self-Improvement Loop Complete ==="
+
+      if [ -f "{{output_dir}}/self_improve/self_improve_summary.json" ]; then
+        cat "{{output_dir}}/self_improve/self_improve_summary.json"
+      else
+        echo '{"status": "self-improvement did not produce a summary"}'
+      fi
+    output: "self_improve_result"
+    parse_json: true
+
+  # ==========================================================================
+  # FINAL OUTPUT
+  # ==========================================================================
+  - id: "final-output"
+    type: "bash"
+    parse_json: true
+    command: |
+      cat << 'EOF'
+      {
+        "workflow": "long-horizon-memory-eval",
+        "version": "2.0.0",
+        "num_turns": "{{num_turns}}",
+        "num_questions": "{{num_questions}}",
+        "sdk": "{{sdk}}",
+        "self_improve": "{{self_improve}}",
+        "use_multi_agent": "{{use_multi_agent}}",
+        "status": "complete",
+        "steps_completed": 6,
+        "steps": [
+          "1. Generate Dialogue Data",
+          "2. Feed Turns to Agent",
+          "3. Generate and Ask Questions",
+          "4. Score and Analyze",
+          "5. Document Findings",
+          "6. Self-Improvement Loop"
+        ],
+        "outputs": {
+          "dialogue": "{{output_dir}}/dialogue.json",
+          "questions": "{{output_dir}}/questions.json",
+          "eval_report": "{{output_dir}}/eval_report.json",
+          "analysis": "{{output_dir}}/long_horizon_analysis.md",
+          "self_improve": "{{output_dir}}/self_improve/self_improve_summary.json"
+        }
+      }
+      EOF
+    output: "final_result"


### PR DESCRIPTION
Refs rysweet/amplihack-rs#284

## Problem
Eval recipes (`domain-agent-eval.yaml`, `long-horizon-memory-eval.yaml`) lived in `rysweet/amplihack/amplifier-bundle/recipes/` and the mirrored copy in `rysweet/amplihack-rs`. This kept them co-tenant with non-eval code and forced the main amplihack Python package to keep its `amplihack.eval.*` modules around to satisfy recipe imports.

## Fix
Move the recipes here as their canonical location. This repo already ships `amplihack_eval` with several of the imported symbols, so two import paths are rewired immediately:
- `amplihack.eval.long_horizon_data` → `amplihack_eval.data.long_horizon`
- `amplihack.eval.test_levels` → `amplihack_eval.data.progressive_levels`

## Out of scope (follow-up issues)
6 modules still imported from upstream `amplihack` package — see `recipes/README.md` table. Their full port requires also bringing `amplihack.agents.domain_agents.*` and `amplihack.llm`, which is larger structural work.

## Companion PR
A separate PR will remove the duplicated recipes from rysweet/amplihack and rysweet/amplihack-rs once this lands.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>