### PR TITLE
feat(eval): port self-contained eval modules from amplihack (#48)

### DIFF
--- a/docs/LONG_HORIZON_EVAL.md
+++ b/docs/LONG_HORIZON_EVAL.md
@@ -1,6 +1,26 @@
 # Long-Horizon Memory Evaluation
 
+## Module Locations (issue #48)
+
+The long-horizon memory eval modules now live in this repo under
+`amplihack_eval.eval.*`:
+
+- `amplihack_eval.eval.long_horizon_memory` — the core 1000-turn eval
+  driver (CLI: `python -m amplihack_eval.eval.long_horizon_memory`).
+- `amplihack_eval.eval.long_horizon_self_improve` — the self-improvement
+  loop wrapper, including the `--multi-agent` mode (CLI:
+  `python -m amplihack_eval.eval.long_horizon_self_improve`).
+- `amplihack_eval.eval.progressive_test_suite` — the L1–L12 progressive
+  test driver used during analyze/diagnose phases.
+- `amplihack_eval.eval.grader` / `metacognition_grader` / `llm_grader` —
+  semantic graders used by the self-improvement loop.
+
+These modules were ported from the upstream `amplihack.eval.*` namespace.
+Recipes (`recipes/long-horizon-memory-eval.yaml`) reference the new paths.
+See `recipes/README.md` for the full porting status table.
+
 ## What It Tests
+
 
 The long-horizon memory evaluation is a stress test for AI agent memory systems.
 It generates a structured dialogue of up to 5000 turns, feeds each turn to the

--- a/docs/ported-modules.md
+++ b/docs/ported-modules.md
@@ -1,0 +1,86 @@
+# Ported Eval Modules (issue #48)
+
+This document tracks modules ported from the upstream `amplihack.eval.*`
+namespace into `amplihack_eval.eval.*` so this repo owns them directly.
+
+## Status
+
+| Upstream module                           | Local module                                 | Status     |
+| ----------------------------------------- | -------------------------------------------- | ---------- |
+| `amplihack.eval.progressive_test_suite`   | `amplihack_eval.eval.progressive_test_suite` | ✅ ported  |
+| `amplihack.eval.long_horizon_memory`      | `amplihack_eval.eval.long_horizon_memory`    | ✅ ported  |
+| `amplihack.eval.long_horizon_self_improve`| `amplihack_eval.eval.long_horizon_self_improve` | ✅ ported |
+| `amplihack.eval.grader`                   | `amplihack_eval.eval.grader`                 | ✅ ported  |
+| `amplihack.eval.llm_grader`               | `amplihack_eval.eval.llm_grader`             | ✅ ported  |
+| `amplihack.eval.metacognition_grader`     | `amplihack_eval.eval.metacognition_grader`   | ✅ ported  |
+| `amplihack.llm.completion`                | `amplihack_eval.llm.completion` (lazy shim)  | ✅ shimmed |
+| `amplihack.eval.run_domain_evals`         | —                                            | ⏳ deferred |
+| `amplihack.eval.teaching_session`         | —                                            | ⏳ deferred |
+| `amplihack.eval.teaching_eval`            | —                                            | ⏳ deferred |
+| `amplihack.eval.domain_eval_harness`      | —                                            | ⏳ deferred |
+| `amplihack.eval.agent_subprocess`         | —                                            | ⏳ deferred |
+| `amplihack.eval.teaching_subprocess`      | —                                            | ⏳ deferred |
+
+## LLM shim contract (`amplihack_eval.llm`)
+
+`amplihack_eval.llm` exposes a single name, `completion`, as a *lazy*
+re-export of `amplihack.llm.completion`:
+
+- Importing `amplihack_eval.llm` is **import-time safe** — it does not
+  itself import `amplihack`.
+- The first call to `await completion(...)` resolves `amplihack.llm.completion`
+  and forwards arguments. If the upstream package is unavailable, an
+  `ImportError` is raised **at call time** with an actionable install
+  hint (`pip install amplihack`).
+
+This keeps the ported eval modules importable in test environments that
+do not have the upstream `amplihack` package installed.
+
+## Grader disambiguation
+
+Two distinct `Grader`-style modules coexist in this repo. They are
+separate code paths with different upstream sources and different LLM
+backends; the right one to use depends on context.
+
+| Module                              | Class / functions          | LLM backend                       | Origin                       |
+| ----------------------------------- | -------------------------- | --------------------------------- | ---------------------------- |
+| `amplihack_eval.core.grader`        | `GradeResult`, `grade_answer` | Anthropic SDK (direct)         | Native to this repo          |
+| `amplihack_eval.eval.grader`        | `GradeResult`, `Grader`, `grade_answer` | Routed via `amplihack_eval.llm.completion` (LLM router) | Ported from `amplihack.eval.grader` (issue #48) |
+
+Both are exercised by code in this repo; they are not interchangeable.
+Tests in `tests/test_ported_eval_modules.py` lock down the distinction.
+
+## Deferred follow-up work
+
+The following items are intentionally out of scope for issue #48 and
+tracked separately:
+
+- **`amplihack.agents.domain_agents.*`** — depended on by
+  `run_domain_evals`, `teaching_session`, `teaching_eval`, and the
+  subprocess targets. Likely needs a separate `amplihack-agents`
+  package or in-repo port.
+- **`amplihack.agents.goal_seeking.runtime_factory` / `learning_agent`
+  / `sub_agents`** — referenced by lazy imports inside
+  `long_horizon_memory.run_eval` and
+  `long_horizon_self_improve.run_long_horizon_self_improve`. They are
+  imported only when the eval is actually executed; import-only smoke
+  tests are unaffected.
+- **Subprocess targets `amplihack.eval.{agent_subprocess,
+  teaching_subprocess}`** — invoked via `python -m ...` from the ported
+  `progressive_test_suite`. The string literals still reference the
+  upstream module paths; running the learning/testing/teaching
+  subprocesses still requires the upstream `amplihack` package on
+  `PATH`. Module-level commentary in
+  `src/amplihack_eval/eval/progressive_test_suite.py` documents this.
+
+## Verification
+
+`tests/test_ported_eval_modules.py` provides:
+
+- Import-smoke checks for all 7 new modules / shim
+- Shim contract checks (callable `completion`, lazy import behavior)
+- Grader disambiguation (distinct namespaces)
+- Progressive level lookup (L1 retrievable from a public container)
+- Long-horizon CLI surface (`main`, `--multi-agent` flag)
+- Recipe YAML rewrite checks (no stale `amplihack.eval.*` refs for
+  ported leaf modules in either recipe)

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -35,12 +35,17 @@ with this repo:
 | -------------------------------------------- | ---------- | -------------------------------------------- |
 | `amplihack_eval.data.long_horizon`           | ✅ here    | `src/amplihack_eval/data/long_horizon.py`    |
 | `amplihack_eval.data.progressive_levels`     | ✅ here    | `src/amplihack_eval/data/progressive_levels.py` |
-| `amplihack.eval.run_domain_evals`            | ⏳ upstream | needs port from `rysweet/amplihack` |
-| `amplihack.eval.teaching_session`            | ⏳ upstream | needs port from `rysweet/amplihack` |
-| `amplihack.eval.teaching_eval`               | ⏳ upstream | needs port from `rysweet/amplihack` |
-| `amplihack.eval.progressive_test_suite`      | ⏳ upstream | needs port from `rysweet/amplihack` |
-| `amplihack.eval.long_horizon_memory`         | ⏳ upstream | needs port from `rysweet/amplihack` |
-| `amplihack.eval.long_horizon_self_improve`   | ⏳ upstream | needs port from `rysweet/amplihack` |
+| `amplihack_eval.eval.progressive_test_suite` | ✅ here    | `src/amplihack_eval/eval/progressive_test_suite.py` (issue #48) |
+| `amplihack_eval.eval.long_horizon_memory`    | ✅ here    | `src/amplihack_eval/eval/long_horizon_memory.py` (issue #48) |
+| `amplihack_eval.eval.long_horizon_self_improve` | ✅ here | `src/amplihack_eval/eval/long_horizon_self_improve.py` (issue #48) |
+| `amplihack_eval.eval.grader`                 | ✅ here    | `src/amplihack_eval/eval/grader.py` (issue #48) |
+| `amplihack_eval.eval.metacognition_grader`   | ✅ here    | `src/amplihack_eval/eval/metacognition_grader.py` (issue #48) |
+| `amplihack_eval.eval.llm_grader`             | ✅ here    | `src/amplihack_eval/eval/llm_grader.py` (issue #48) |
+| `amplihack.eval.run_domain_evals`            | ⏳ upstream | needs port (depends on `amplihack.agents.domain_agents.*`) |
+| `amplihack.eval.teaching_session`            | ⏳ upstream | needs port (depends on `amplihack.llm.completion`) |
+| `amplihack.eval.teaching_eval`               | ⏳ upstream | needs port (depends on `amplihack.agents.domain_agents.base`) |
+| `amplihack.eval.agent_subprocess`            | ⏳ upstream | invoked via subprocess from `progressive_test_suite` |
+| `amplihack.eval.teaching_subprocess`         | ⏳ upstream | invoked via subprocess from `progressive_test_suite` |
 
 The upstream-pending modules also depend on `amplihack.agents.domain_agents.*`
 and `amplihack.llm`, so a full port requires either bringing those packages

--- a/recipes/long-horizon-memory-eval.yaml
+++ b/recipes/long-horizon-memory-eval.yaml
@@ -33,13 +33,13 @@ tags: ["eval", "memory", "long-horizon", "stress-test", "1000-turn"]
 #   }'
 #
 # CLI equivalent:
-#   python -m amplihack.eval.long_horizon_memory --turns 1000 --questions 100
+#   python -m amplihack_eval.eval.long_horizon_memory --turns 1000 --questions 100
 #
 # Self-improvement loop:
-#   python -m amplihack.eval.long_horizon_self_improve --turns 100 --questions 20
+#   python -m amplihack_eval.eval.long_horizon_self_improve --turns 100 --questions 20
 #
 # Multi-agent variant:
-#   python -m amplihack.eval.long_horizon_self_improve --turns 100 --questions 20 --multi-agent
+#   python -m amplihack_eval.eval.long_horizon_self_improve --turns 100 --questions 20 --multi-agent
 
 recursion:
   max_depth: 4
@@ -154,7 +154,7 @@ steps:
 
       # Convert to article format for learning subprocess
       from amplihack_eval.data.progressive_levels import TestArticle
-      from amplihack.eval.progressive_test_suite import run_learning_subprocess
+      from amplihack_eval.eval.progressive_test_suite import run_learning_subprocess
 
       # Batch turns into chunks of 50 for efficiency
       batch_size = 50
@@ -261,7 +261,7 @@ steps:
     command: |
       echo "=== Step 4: Scoring and Analyzing ==="
 
-      PYTHONPATH=src python -m amplihack.eval.long_horizon_memory \
+      PYTHONPATH=src python -m amplihack_eval.eval.long_horizon_memory \
         --turns {{num_turns}} \
         --questions {{num_questions}} \
         --sdk {{sdk}} \
@@ -364,7 +364,7 @@ steps:
         MULTI_AGENT_FLAG="--multi-agent"
       fi
 
-      PYTHONPATH=src python -m amplihack.eval.long_horizon_self_improve \
+      PYTHONPATH=src python -m amplihack_eval.eval.long_horizon_self_improve \
         --turns {{num_turns}} \
         --questions {{num_questions}} \
         --iterations {{max_iterations}} \

--- a/src/amplihack_eval/data/hive_mind_scenarios.py
+++ b/src/amplihack_eval/data/hive_mind_scenarios.py
@@ -147,6 +147,7 @@ _INFRA_SECURITY_FACTS = [
     "Zero-trust architecture is enforced via SPIFFE/SPIRE for workload identity.",
     "Secret rotation period is 30 days for database credentials and 90 days for API keys.",
     "SIEM aggregation runs on Splunk Enterprise with 90-day hot storage retention.",
+    "Runtime threat detection uses Falco with custom rule sets tailored to containerd workloads.",
     "SOC2 Type II audit was completed in November 2025 with zero findings.",
     "WAF rules block the OWASP Top 10 attack patterns on all public endpoints.",
     "Certificate management uses cert-manager with Let's Encrypt for public certs.",
@@ -269,6 +270,7 @@ SCENARIO_INFRA = HiveMindScenario(
             question_id="hive_infra_q10",
             text="What vulnerability scanning tools are used and how are container images secured before deployment to the cluster?",
             required_domains=["security", "compute"],
+            expected_keywords=["Falco", "Cosign", "containerd"],
             difficulty="cross_domain",
         ),
         # 5 synthesis questions

--- a/src/amplihack_eval/eval/__init__.py
+++ b/src/amplihack_eval/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Eval modules ported from ``amplihack.eval`` (issue #48)."""

--- a/src/amplihack_eval/eval/grader.py
+++ b/src/amplihack_eval/eval/grader.py
@@ -1,0 +1,228 @@
+"""Semantic grader for quiz answers.
+
+Uses LLM to semantically evaluate agent answers against expected answers.
+Supports multi-vote grading (majority vote across N calls) to reduce noise.
+Philosophy: Single responsibility - just grading, no other logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import statistics
+from dataclasses import dataclass
+
+from .llm_grader import call_grader_json, get_grader_model
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GradeResult:
+    """Result of grading an answer."""
+
+    score: float  # 0.0 to 1.0
+    reasoning: str
+    vote_scores: list[float] | None = None  # Individual vote scores when multi-vote
+
+
+def _build_grading_prompt(question: str, expected: str, actual: str, level: str) -> str:
+    """Build the grading prompt for LLM evaluation.
+
+    Args:
+        question: The quiz question
+        expected: Expected answer
+        actual: Agent's actual answer
+        level: Cognitive level
+
+    Returns:
+        Formatted prompt string
+    """
+    # Level-specific grading criteria
+    level_criteria = ""
+    if level == "L3":
+        level_criteria = (
+            "\n\nL3 TEMPORAL REASONING grading criteria:\n"
+            "- The NUMERICAL values (differences, totals) are the PRIMARY grading dimension.\n"
+            "  If the agent computes the correct numbers, award at least 0.7.\n"
+            "- TREND DIRECTION is secondary. Accept any of these as describing a decrease:\n"
+            "  'deceleration', 'slowing', 'slowed', 'decreased rate', 'less in later period'\n"
+            "  These all mean the SAME THING as the expected answer's trend description.\n"
+            "- Award 0.9-1.0 if the agent gets BOTH correct numbers AND correct trend direction.\n"
+        )
+    elif level == "L5":
+        level_criteria = (
+            "\n\nL5 EXPLICIT GRADING CRITERIA for contradiction acknowledgment:\n"
+            "Award 0.9-1.0 if the agent:\n"
+            "  - Names BOTH conflicting values/claims with their sources\n"
+            "  - Uses language like 'conflicting', 'disagree', 'different reports'\n"
+            "Award 0.6-0.8 if the agent:\n"
+            "  - Mentions both values but does not explicitly flag the conflict\n"
+            "  - Or flags the conflict but misattributes a source\n"
+            "Award 0.3-0.5 if the agent:\n"
+            "  - Only presents one value but hints at uncertainty\n"
+            "Award 0.0-0.2 if the agent:\n"
+            "  - Presents only one value with no mention of disagreement\n"
+        )
+
+    return f"""You are grading an AI agent's answer to a quiz question.
+
+Cognitive Level: {level}
+- L1 (Recall): Direct facts, must be factually accurate
+- L2 (Multi-Source Synthesis): Combining information from multiple sources
+- L3 (Temporal Reasoning): Understanding changes over time, computing differences
+- L4 (Procedural Learning): Learning and applying step-by-step procedures
+- L5 (Contradiction Handling): Detecting and reasoning about conflicting information
+- L6 (Incremental Learning): Updating knowledge when new information arrives
+
+Question: {question}
+
+Expected Answer: {expected}
+
+Agent's Answer: {actual}
+
+Grade the agent's answer on a scale of 0.0 to 1.0:
+- 1.0: Perfect match or semantically equivalent
+- 0.8-0.9: Correct main points, minor differences
+- 0.6-0.7: Partially correct, missing some details
+- 0.4-0.5: Some relevant content, significant gaps
+- 0.0-0.3: Incorrect or unrelated
+
+Special considerations:
+- L5 (Contradictions): Award full points if agent acknowledges the contradiction, even if they don't resolve it
+- L6 (Updates): Agent must use the MOST RECENT information, not outdated data
+- L7 (Teaching): Grade based on factual accuracy of the answer, regardless of how it was learned
+- L9 (Causal): When asking about "most important single factor" or "root cause", accept
+  EITHER "program restructuring after 2018" OR "winning the hosting bid" as valid root causes.
+  Both are defensible interpretations. Score 0.8+ if the agent picks either and provides
+  sound causal reasoning explaining why that factor is the root cause.
+- L11 (Novel Skill): For workflow/config generation, grade on correctness of REQUIRED fields.
+  Do NOT penalize for including extra optional fields if the required ones are correct.
+- L12 (Far Transfer): When computing ratios and trends, the DIRECTION of the trend
+  (improving vs worsening) is critical. Correct ratio computation with wrong trend
+  direction should score 0.5-0.6, not 0.8+.
+- IMPORTANT: If the agent shows work/reasoning, look at the FINAL CONCLUSION,
+  not just the opening line. Agents may self-correct during reasoning.
+  The final answer at the end of the response is what matters.
+{level_criteria}
+Return ONLY a JSON object with this structure:
+{{"score": 0.85, "reasoning": "Brief explanation of grade"}}"""
+
+
+def _single_grade_call(model: str, prompt: str) -> GradeResult:
+    """Execute a single grading LLM call.
+
+    Args:
+        model: Model identifier
+        prompt: Grading prompt
+
+    Returns:
+        GradeResult from this single call
+    """
+    result_json = asyncio.run(call_grader_json(prompt, model=model, max_tokens=500))
+
+    return GradeResult(
+        score=float(result_json["score"]),
+        reasoning=result_json["reasoning"],
+    )
+
+
+def grade_answer(
+    question: str,
+    expected: str,
+    actual: str,
+    level: str,
+    num_votes: int = 1,
+) -> GradeResult:
+    """Grade an answer using semantic comparison with optional multi-vote.
+
+    When num_votes > 1, runs multiple independent grading calls and takes
+    the median score as the final grade. This reduces grading noise on
+    ambiguous answers.
+
+    Args:
+        question: The quiz question
+        expected: Expected answer
+        actual: Agent's actual answer
+        level: Cognitive level (L1, L2, L3, L4, L5, L6, etc.)
+        num_votes: Number of grading calls (1 = single, 3 = majority vote)
+
+    Returns:
+        GradeResult with score, reasoning, and optional vote_scores
+    """
+    if not question or not question.strip():
+        raise ValueError("Question must be a non-empty string")
+    if not expected or not expected.strip():
+        raise ValueError("Expected answer must be a non-empty string")
+    if not actual or not actual.strip():
+        return GradeResult(score=0.0, reasoning="Agent provided no answer")
+
+    grader_model = get_grader_model()
+    prompt = _build_grading_prompt(question, expected, actual, level)
+
+    # Clamp num_votes to valid range
+    num_votes = max(1, min(num_votes, 9))
+
+    if num_votes == 1:
+        return _single_grade_call(grader_model, prompt)
+
+    # Multi-vote: run N grading calls and take median
+    vote_results: list[GradeResult] = []
+    for vote_idx in range(num_votes):
+        try:
+            result = _single_grade_call(grader_model, prompt)
+            vote_results.append(result)
+        except Exception as e:
+            logger.warning("Grading vote %d failed: %s", vote_idx, e)
+            continue
+
+    if not vote_results:
+        raise RuntimeError("All grading votes failed")
+
+    vote_scores = [r.score for r in vote_results]
+    median_score = statistics.median(vote_scores)
+
+    # Use reasoning from the vote closest to the median
+    closest_vote = min(vote_results, key=lambda r: abs(r.score - median_score))
+
+    return GradeResult(
+        score=median_score,
+        reasoning=f"[{num_votes}-vote median] {closest_vote.reasoning}",
+        vote_scores=vote_scores,
+    )
+
+
+__all__ = ["grade_answer", "GradeResult", "Grader"]
+
+
+class Grader:
+    """Object-oriented wrapper around :func:`grade_answer`.
+
+    Mirrors the upstream functional interface but allows callers to
+    pre-bind grading defaults (like ``num_votes``) when grading multiple
+    answers in sequence. Distinct from :class:`amplihack_eval.core.grader`
+    which is a separate Anthropic-direct grader used by other parts of
+    this repository — see ``docs/ported-modules.md``.
+    """
+
+    def __init__(self, num_votes: int = 1) -> None:
+        if num_votes < 1:
+            raise ValueError("num_votes must be >= 1")
+        self.num_votes = num_votes
+
+    def grade(
+        self,
+        question: str,
+        expected: str,
+        actual: str,
+        level: str,
+        num_votes: int | None = None,
+    ) -> GradeResult:
+        """Grade an answer, delegating to :func:`grade_answer`."""
+        return grade_answer(
+            question=question,
+            expected=expected,
+            actual=actual,
+            level=level,
+            num_votes=num_votes if num_votes is not None else self.num_votes,
+        )

--- a/src/amplihack_eval/eval/llm_grader.py
+++ b/src/amplihack_eval/eval/llm_grader.py
@@ -1,0 +1,76 @@
+"""Shared LLM grading helpers for eval modules."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+from amplihack_eval.llm import completion
+
+DEFAULT_GRADER_MODEL = "claude-opus-4-6"
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    """Extract a JSON object from LLM response text."""
+    stripped = text.strip()
+
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+
+    fenced = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", stripped, re.DOTALL)
+    if fenced:
+        try:
+            return json.loads(fenced.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+
+    brace_match = re.search(r"\{.*\}", stripped, re.DOTALL)
+    if brace_match:
+        try:
+            return json.loads(brace_match.group(0))
+        except json.JSONDecodeError:
+            pass
+
+    raise json.JSONDecodeError(f"No valid JSON found in response: {stripped[:200]}", stripped, 0)
+
+
+def get_grader_model(explicit_model: str | None = None) -> str:
+    """Resolve the grader model from an explicit override or environment."""
+    return explicit_model or os.environ.get("GRADER_MODEL", DEFAULT_GRADER_MODEL)
+
+
+async def call_grader_json(
+    prompt: str,
+    *,
+    model: str | None = None,
+    max_tokens: int = 1000,
+    temperature: float | None = None,
+    system: str | None = None,
+) -> dict[str, Any]:
+    """Run a grading prompt through the LLM adapter and parse the JSON response."""
+    resolved_model = get_grader_model(model)
+
+    messages: list[dict[str, str]] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+
+    response_text = await completion(
+        messages,
+        model=resolved_model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return extract_json(response_text)
+
+
+__all__ = [
+    "DEFAULT_GRADER_MODEL",
+    "call_grader_json",
+    "extract_json",
+    "get_grader_model",
+]

--- a/src/amplihack_eval/eval/long_horizon_memory.py
+++ b/src/amplihack_eval/eval/long_horizon_memory.py
@@ -1,0 +1,1696 @@
+"""Long-horizon memory stress test for goal-seeking agents.
+
+Philosophy:
+- 1000-turn dialogue tests memory at scale (not just short-horizon recall)
+- Deterministic data generation, reproducible results
+- Hybrid deterministic + LLM grading: rubric keywords scored without LLM,
+  judgment dimensions (confidence, source attribution) use LLM
+- Multi-vote grading for stability: grade N times, take median per dimension
+- Agent-agnostic: works with any LearningAgent-compatible interface
+
+Migration note:
+    The standalone ``amplihack-agent-eval`` package provides a superset of this
+    module. When installed, data types and runner are imported from the package
+    to ensure a single source of truth. When not installed, this module's local
+    implementations are used (backward compatible).
+
+Public API:
+    LongHorizonMemoryEval: Main evaluation class
+    EvalResult: Per-question result with scores
+    EvalReport: Aggregate report with breakdown by category
+
+Usage:
+    python -m amplihack_eval.eval.long_horizon_memory --turns 100 --questions 20
+    python -m amplihack_eval.eval.long_horizon_memory --turns 1000 --questions 100
+    python -m amplihack_eval.eval.long_horizon_memory --sdk claude --grader-votes 5
+    python -m amplihack_eval.eval.long_horizon_memory --turns 100 --questions 20 --parallel-workers 10
+
+    # Large-scale with subprocess segmentation (prevents OOM on 5000+ turns):
+    python -m amplihack_eval.eval.long_horizon_memory --turns 5000 --segment-size 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import logging
+import os
+import re
+import statistics
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .llm_grader import call_grader_json, get_grader_model
+
+# Keep this in sync with pyproject.toml's direct git dependency pin.
+AMPLIHACK_AGENT_EVAL_REV = "d7a28a552bed6e8daa752e465475024b281913f6"  # pragma: allowlist secret
+AMPLIHACK_AGENT_EVAL_INSTALL = (
+    "pip install 'amplihack-agent-eval @ "
+    "git+https://github.com/rysweet/amplihack-agent-eval.git@"
+    f"{AMPLIHACK_AGENT_EVAL_REV}'"
+)
+
+# Requires amplihack-agent-eval package.
+# Install: pip install "amplihack-agent-eval @ git+https://github.com/rysweet/amplihack-agent-eval.git@d7a28a552bed6e8daa752e465475024b281913f6"
+try:
+    from amplihack_eval.data.long_horizon import (  # type: ignore[import-not-found]
+        GradingRubric,
+        GroundTruth,
+        Question,
+        generate_dialogue,
+        generate_questions,
+    )
+except ImportError:
+    raise ImportError(
+        f"amplihack-agent-eval package is required but not installed. Install with: {AMPLIHACK_AGENT_EVAL_INSTALL}"
+    )
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DimensionScore:
+    """Score on a single dimension for a single question."""
+
+    dimension: str
+    score: float  # 0.0 to 1.0
+    reasoning: str = ""
+
+
+@dataclass
+class EvalResult:
+    """Result for a single question."""
+
+    question_id: str
+    question_text: str
+    category: str
+    expected_answer: str
+    actual_answer: str
+    dimensions: list[DimensionScore]
+    overall_score: float  # Average of dimension scores
+    grading_time_s: float = 0.0
+
+
+@dataclass
+class CategoryBreakdown:
+    """Aggregate scores for a question category."""
+
+    category: str
+    num_questions: int
+    avg_score: float
+    min_score: float
+    max_score: float
+    dimension_averages: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class EvalReport:
+    """Complete evaluation report."""
+
+    num_turns: int
+    num_questions: int
+    total_facts_delivered: int
+    learning_time_s: float
+    questioning_time_s: float
+    grading_time_s: float
+    overall_score: float
+    category_breakdown: list[CategoryBreakdown]
+    results: list[EvalResult]
+    memory_stats: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert report to dictionary for JSON serialization."""
+        return {
+            "num_turns": self.num_turns,
+            "num_questions": self.num_questions,
+            "total_facts_delivered": self.total_facts_delivered,
+            "learning_time_s": round(self.learning_time_s, 2),
+            "questioning_time_s": round(self.questioning_time_s, 2),
+            "grading_time_s": round(self.grading_time_s, 2),
+            "overall_score": round(self.overall_score, 4),
+            "category_breakdown": [
+                {
+                    "category": cb.category,
+                    "num_questions": cb.num_questions,
+                    "avg_score": round(cb.avg_score, 4),
+                    "min_score": round(cb.min_score, 4),
+                    "max_score": round(cb.max_score, 4),
+                    "dimension_averages": {k: round(v, 4) for k, v in cb.dimension_averages.items()},
+                }
+                for cb in self.category_breakdown
+            ],
+            "results": [
+                {
+                    "question_id": r.question_id,
+                    "question_text": r.question_text,
+                    "category": r.category,
+                    "expected_answer": r.expected_answer,
+                    "actual_answer": r.actual_answer[:500],
+                    "overall_score": round(r.overall_score, 4),
+                    "dimensions": [
+                        {
+                            "dimension": d.dimension,
+                            "score": round(d.score, 4),
+                            "reasoning": d.reasoning[:200],
+                        }
+                        for d in r.dimensions
+                    ],
+                }
+                for r in self.results
+            ],
+            "memory_stats": self.memory_stats,
+        }
+
+
+# Scoring dimensions
+ALL_DIMENSIONS = [
+    "factual_accuracy",
+    "specificity",
+    "temporal_awareness",
+    "source_attribution",
+    "confidence_calibration",
+]
+
+
+# Dimensions that can be graded deterministically when a rubric is present
+_DETERMINISTIC_DIMENSIONS = {"factual_accuracy", "specificity"}
+
+# Dimensions that always require LLM judgment
+_LLM_ONLY_DIMENSIONS = {"confidence_calibration", "source_attribution", "temporal_awareness"}
+
+
+def _deterministic_grade(
+    rubric: GradingRubric,
+    actual_answer: str,
+    dimensions: list[str],
+) -> dict[str, DimensionScore]:
+    """Grade deterministic dimensions using regex/string matching against rubric.
+
+    Returns a dict mapping dimension name -> DimensionScore for every dimension
+    in `dimensions` that can be scored deterministically. Dimensions not in
+    _DETERMINISTIC_DIMENSIONS are skipped (returned dict won't contain them).
+
+    Scoring logic:
+    - Start with keyword match ratio (required_keywords found / total required)
+    - Bonus +0.25 for each acceptable_paraphrase found (capped at 1.0)
+    - incorrect_patterns only zero the score when NONE of the required keywords
+      or paraphrases match. When the correct answer IS present alongside an
+      incorrect pattern (e.g. "increased from $1.2M to $1.4M"), the answer is
+      providing historical context, not a wrong answer.
+    """
+    answer_lower = actual_answer.lower()
+    scores: dict[str, DimensionScore] = {}
+
+    for dim in dimensions:
+        if dim not in _DETERMINISTIC_DIMENSIONS:
+            continue
+
+        # Keyword matching
+        matched = 0
+        if rubric.required_keywords:
+            matched = sum(1 for kw in rubric.required_keywords if re.search(re.escape(kw.lower()), answer_lower))
+            ratio = matched / len(rubric.required_keywords)
+        else:
+            ratio = 0.5  # No keywords = neutral
+
+        # Paraphrase bonus -- each paraphrase match adds 0.25 (a paraphrase IS
+        # a valid answer form, so it should carry significant weight). When NO
+        # keywords matched (ratio=0) but paraphrases did, the answer is still
+        # semantically correct.
+        paraphrase_hits = 0
+        if rubric.acceptable_paraphrases:
+            paraphrase_hits = sum(
+                1 for p in rubric.acceptable_paraphrases if re.search(re.escape(p.lower()), answer_lower)
+            )
+            ratio = min(1.0, ratio + paraphrase_hits * 0.25)
+
+        # Check incorrect patterns AFTER keyword matching. Only skip incorrect
+        # check when ALL required keywords match (full correct answer present).
+        # Partial matches (some keywords) still get checked for incorrect patterns.
+        all_keywords_matched = rubric.required_keywords and matched == len(rubric.required_keywords)
+        has_full_correct = all_keywords_matched or paraphrase_hits > 0
+        if rubric.incorrect_patterns and not has_full_correct:
+            found_incorrect = any(re.search(re.escape(pat.lower()), answer_lower) for pat in rubric.incorrect_patterns)
+            if found_incorrect:
+                scores[dim] = DimensionScore(
+                    dimension=dim,
+                    score=0.0,
+                    reasoning="Answer contains incorrect pattern without correct keywords",
+                )
+                continue
+
+        reasoning_parts = []
+        if rubric.required_keywords:
+            reasoning_parts.append(f"Matched {matched}/{len(rubric.required_keywords)} required keywords")
+        if rubric.acceptable_paraphrases and paraphrase_hits:
+            reasoning_parts.append(f"+{paraphrase_hits} paraphrase bonus")
+
+        scores[dim] = DimensionScore(
+            dimension=dim,
+            score=round(ratio, 4),
+            reasoning="; ".join(reasoning_parts) if reasoning_parts else "Deterministic score",
+        )
+
+    return scores
+
+
+def _grade_hybrid(
+    question: Question,
+    actual_answer: str,
+    dimensions: list[str],
+    grader_model: str = "",
+) -> list[DimensionScore]:
+    """Hybrid grading: deterministic for rubric-compatible dimensions, LLM for the rest.
+
+    If the question has a rubric, factual_accuracy and specificity are scored
+    deterministically. Remaining dimensions (temporal_awareness,
+    source_attribution, confidence_calibration) are sent to the LLM.
+    If no rubric exists, all dimensions go to LLM (backward compatible).
+    """
+    if not question.rubric:
+        return _grade_with_llm(question, actual_answer, dimensions, grader_model)
+
+    # Score deterministic dimensions
+    det_scores = _deterministic_grade(question.rubric, actual_answer, dimensions)
+
+    # Remaining dimensions need LLM
+    remaining = [d for d in dimensions if d not in det_scores]
+
+    if remaining:
+        llm_scores = _grade_with_llm(question, actual_answer, remaining, grader_model)
+        llm_map = {s.dimension: s for s in llm_scores}
+    else:
+        llm_map = {}
+
+    # Merge in original order
+    result: list[DimensionScore] = []
+    for dim in dimensions:
+        if dim in det_scores:
+            result.append(det_scores[dim])
+        elif dim in llm_map:
+            result.append(llm_map[dim])
+        else:
+            result.append(DimensionScore(dimension=dim, score=0.0, reasoning="Not graded"))
+
+    # Apply dimension weights from rubric if provided
+    if question.rubric.dimension_weights:
+        for ds in result:
+            if ds.dimension in question.rubric.dimension_weights:
+                w = question.rubric.dimension_weights[ds.dimension]
+                ds.score = round(ds.score * w, 4)
+                ds.reasoning += f" (weight={w})"
+
+    return result
+
+
+def _grade_multi_vote(
+    question: Question,
+    actual_answer: str,
+    dimensions: list[str],
+    grader_model: str = "",
+    num_votes: int = 3,
+) -> list[DimensionScore]:
+    """Grade with multiple votes and take median score per dimension.
+
+    Calls _grade_hybrid N times concurrently and returns the median score per
+    dimension. For N=1, this is equivalent to a single call (no overhead).
+    When N>1, votes are submitted to a ThreadPoolExecutor for parallel execution.
+    """
+    if num_votes <= 1:
+        return _grade_hybrid(question, actual_answer, dimensions, grader_model)
+
+    # Collect all vote results using parallel execution
+    all_votes: dict[str, list[float]] = {d: [] for d in dimensions}
+    all_reasoning: dict[str, list[str]] = {d: [] for d in dimensions}
+
+    def _do_vote() -> list[DimensionScore]:
+        return _grade_hybrid(question, actual_answer, dimensions, grader_model)
+
+    with ThreadPoolExecutor(max_workers=num_votes) as executor:
+        futures = [executor.submit(_do_vote) for _ in range(num_votes)]
+        for future in futures:
+            try:
+                scores = future.result()
+                for ds in scores:
+                    all_votes[ds.dimension].append(ds.score)
+                    all_reasoning[ds.dimension].append(ds.reasoning)
+            except Exception as e:
+                logger.warning("Grading vote failed: %s", e)
+                for dim in dimensions:
+                    all_votes[dim].append(0.0)
+                    all_reasoning[dim].append(f"Vote failed: {e}")
+
+    # Take median per dimension
+    result: list[DimensionScore] = []
+    for dim in dimensions:
+        votes = all_votes[dim]
+        median_score = statistics.median(votes) if votes else 0.0
+        # Pick reasoning from the vote closest to median
+        best_idx = min(range(len(votes)), key=lambda i: abs(votes[i] - median_score))
+        reasoning = all_reasoning[dim][best_idx]
+        reasoning += f" [median of {len(votes)} votes: {', '.join(f'{v:.2f}' for v in votes)}]"
+
+        result.append(
+            DimensionScore(
+                dimension=dim,
+                score=round(median_score, 4),
+                reasoning=reasoning,
+            )
+        )
+
+    return result
+
+
+def _grade_with_llm(
+    question: Question,
+    actual_answer: str,
+    dimensions: list[str],
+    grader_model: str = "",
+) -> list[DimensionScore]:
+    """Grade an answer on multiple dimensions using LLM.
+
+    Args:
+        question: The question with expected answer
+        actual_answer: Agent's actual answer
+        dimensions: Which dimensions to score
+        grader_model: Model to use for grading
+
+    Returns:
+        List of DimensionScore for each requested dimension
+    """
+    if not grader_model:
+        grader_model = get_grader_model()
+
+    dimension_descriptions = {
+        "factual_accuracy": "Is the answer factually correct? Does it match the expected answer on key facts?",
+        "specificity": "Does the answer include specific details (names, numbers, dates)?",
+        "temporal_awareness": "Does the answer correctly distinguish current vs historical values?",
+        "source_attribution": "Does the answer correctly attribute information to its source?",
+        "confidence_calibration": "Does the answer express appropriate confidence/uncertainty?",
+    }
+
+    dims_text = "\n".join(f"- {d}: {dimension_descriptions.get(d, 'General quality')}" for d in dimensions)
+
+    prompt = f"""Grade this answer on the following dimensions (0.0 to 1.0 each):
+
+{dims_text}
+
+Question: {question.text}
+Category: {question.category}
+
+Expected Answer: {question.expected_answer}
+
+Actual Answer: {actual_answer}
+
+Return ONLY a JSON object mapping each dimension to a score and reasoning:
+{{
+  "scores": {{
+    "factual_accuracy": {{"score": 0.85, "reasoning": "..."}},
+    ...
+  }}
+}}
+
+Scoring guide:
+- 1.0: Perfect or semantically equivalent
+- 0.8-0.9: Correct main points, minor differences
+- 0.5-0.7: Partially correct, missing key details
+    - 0.2-0.4: Some relevant content, significant gaps
+    - 0.0-0.1: Incorrect or irrelevant
+    """
+
+    try:
+        result = call_grader_json(prompt, model=grader_model, max_tokens=1000)
+        scores_dict = result.get("scores", result)
+
+        dimension_scores = []
+        for dim in dimensions:
+            if dim in scores_dict:
+                entry = scores_dict[dim]
+                if isinstance(entry, dict):
+                    dimension_scores.append(
+                        DimensionScore(
+                            dimension=dim,
+                            score=float(entry.get("score", 0.0)),
+                            reasoning=str(entry.get("reasoning", "")),
+                        )
+                    )
+                elif isinstance(entry, (int, float)):
+                    dimension_scores.append(
+                        DimensionScore(
+                            dimension=dim,
+                            score=float(entry),
+                            reasoning="",
+                        )
+                    )
+                else:
+                    dimension_scores.append(
+                        DimensionScore(
+                            dimension=dim,
+                            score=0.0,
+                            reasoning="Parse error",
+                        )
+                    )
+            else:
+                dimension_scores.append(
+                    DimensionScore(
+                        dimension=dim,
+                        score=0.0,
+                        reasoning="Not graded",
+                    )
+                )
+
+        return dimension_scores
+    except OSError:
+        return [DimensionScore(dimension=d, score=0.0, reasoning="No API key") for d in dimensions]
+
+    except Exception as e:
+        logger.warning("Grading failed for %s: %s", question.question_id, e)
+        return [DimensionScore(dimension=d, score=0.0, reasoning=f"Error: {e}") for d in dimensions]
+
+
+def _extract_json(text: str) -> dict:
+    """Extract JSON from LLM response text."""
+    import re
+
+    stripped = text.strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+
+    fenced = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", stripped, re.DOTALL)
+    if fenced:
+        try:
+            return json.loads(fenced.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+
+    brace_match = re.search(r"\{.*\}", stripped, re.DOTALL)
+    if brace_match:
+        try:
+            return json.loads(brace_match.group(0))
+        except json.JSONDecodeError:
+            pass
+
+    return {}
+
+
+class LongHorizonMemoryEval:
+    """1000-turn dialogue memory stress test.
+
+    Generates structured dialogue content, feeds it to an agent's learn method,
+    then quizzes the agent on details from various points in the conversation.
+
+    Grading uses a hybrid approach:
+    - Deterministic: factual_accuracy and specificity scored via rubric keywords
+    - LLM: temporal_awareness, source_attribution, confidence_calibration
+    - Multi-vote: each question graded N times, median score per dimension
+
+    Args:
+        num_turns: Number of dialogue turns (default 1000)
+        num_questions: Number of quiz questions (default 100)
+        seed: Random seed for reproducibility (default 42)
+        grader_votes: Number of grading votes per question (default 3)
+        parallel_workers: Number of parallel workers for question answering
+            and grading. Set to 1 for sequential execution (default 10, max 20).
+        flush_every: Flush agent memory every N turns during dialogue to cap
+            memory growth. 0 disables (default 0). Requires the agent to
+            expose a ``flush_memory()`` method (e.g. HierarchicalMemory).
+
+    Example:
+        >>> from amplihack.agents.goal_seeking.learning_agent import LearningAgent
+        >>> agent = LearningAgent("eval_agent", use_hierarchical=True)
+        >>> eval_obj = LongHorizonMemoryEval(num_turns=100, num_questions=20)
+        >>> report = eval_obj.run(agent)
+        >>> print(f"Overall score: {report.overall_score:.2%}")
+    """
+
+    def __init__(
+        self,
+        num_turns: int = 1000,
+        num_questions: int = 100,
+        seed: int = 42,
+        grader_votes: int = 3,
+        parallel_workers: int = 10,
+        flush_every: int = 0,
+        restart_every: int = 0,
+    ):
+        self.num_turns = num_turns
+        self.num_questions = num_questions
+        self.seed = seed
+        self.grader_votes = max(1, grader_votes)
+        self.parallel_workers = max(1, min(20, parallel_workers))
+        self.flush_every = max(0, flush_every)
+        self.restart_every = max(0, restart_every)
+        self.ground_truth: GroundTruth | None = None
+        self.questions: list[Question] = []
+
+    def generate(self) -> tuple[GroundTruth, list[Question]]:
+        """Generate dialogue and questions.
+
+        Returns:
+            Tuple of (GroundTruth, list[Question])
+        """
+        self.ground_truth = generate_dialogue(num_turns=self.num_turns, seed=self.seed)
+        assert self.ground_truth is not None
+        self.questions = generate_questions(self.ground_truth, num_questions=self.num_questions)
+        return self.ground_truth, self.questions
+
+    def run_dialogue(
+        self,
+        agent: Any,
+        ground_truth: GroundTruth | None = None,
+        agent_factory: Any | None = None,
+    ) -> float | tuple[float, Any]:
+        """Feed all turns to the agent's learning method.
+
+        When ``flush_every > 0`` and the agent exposes ``flush_memory()``,
+        the memory connection is periodically recycled to cap in-process
+        cache growth without losing any persisted data.
+
+        Args:
+            agent: Agent with learn_from_content(content) method
+            ground_truth: Override ground truth (uses self.ground_truth if None)
+            agent_factory: Optional callable that returns a fresh agent.
+                Required when restart_every > 0.  Signature: ``() -> agent``.
+
+        Returns:
+            When agent_factory is None: elapsed time in seconds (float).
+            When agent_factory is provided: tuple of (elapsed_seconds, final_agent)
+                so the caller can use the most recent agent instance.
+        """
+        gt = ground_truth or self.ground_truth
+        if gt is None:
+            raise ValueError("Must call generate() first or pass ground_truth")
+
+        flush_every = self.flush_every
+        can_flush = flush_every > 0 and hasattr(agent, "flush_memory")
+        if flush_every > 0 and not can_flush:
+            logger.warning(
+                "flush_every=%d but agent has no flush_memory(); disabling periodic flush",
+                flush_every,
+            )
+
+        restart_every = self.restart_every
+        can_restart = restart_every > 0 and agent_factory is not None
+
+        start = time.time()
+        total = len(gt.turns)
+        flushes = 0
+        restarts = 0
+
+        for i, turn in enumerate(gt.turns):
+            if not turn.content or not turn.content.strip():
+                continue
+
+            try:
+                agent.learn_from_content(turn.content)
+            except Exception as e:
+                logger.warning("Failed to learn turn %d: %s", i, e)
+
+            if (i + 1) % 50 == 0 or i == total - 1:
+                elapsed = time.time() - start
+                rate = (i + 1) / elapsed if elapsed > 0 else 0
+                logger.info(
+                    "Turn %d/%d (%.1f turns/s) - block: %s",
+                    i + 1,
+                    total,
+                    rate,
+                    turn.block_name,
+                )
+
+            # Periodic memory flush to cap cache growth
+            if can_flush and (i + 1) % flush_every == 0 and (i + 1) < total:
+                logger.info(
+                    "Flushing memory at turn %d/%d (flush #%d)",
+                    i + 1,
+                    total,
+                    flushes + 1,
+                )
+                try:
+                    agent.flush_memory()
+                except Exception as e:
+                    logger.warning("flush_memory failed at turn %d: %s", i + 1, e)
+                flushes += 1
+
+            # Periodic agent restart to free memory (issue #2566)
+            if can_restart and (i + 1) % restart_every == 0 and (i + 1) < total:
+                restarts += 1
+                logger.info(
+                    "Restarting agent at turn %d/%d (restart #%d)",
+                    i + 1,
+                    total,
+                    restarts,
+                )
+                try:
+                    agent.close()
+                except Exception as e:
+                    logger.warning("agent.close() failed at turn %d: %s", i + 1, e)
+                del agent
+                gc.collect()
+                assert agent_factory is not None  # guarded by can_restart
+                agent = agent_factory()
+
+        elapsed = time.time() - start
+        logger.info(
+            "Dialogue complete: %d turns in %.1fs (%d flushes, %d restarts)",
+            total,
+            elapsed,
+            flushes,
+            restarts,
+        )
+        if agent_factory is not None:
+            return elapsed, agent
+        return elapsed
+
+    def evaluate(
+        self,
+        agent: Any,
+        questions: list[Question] | None = None,
+        grader_model: str = "",
+    ) -> EvalReport:
+        """Ask questions and grade responses.
+
+        When parallel_workers > 1, questions are answered and graded concurrently
+        using a ThreadPoolExecutor. Results are collected in original question order
+        to ensure deterministic output regardless of worker count.
+
+        Args:
+            agent: Agent with answer_question(question) method
+            questions: Override questions (uses self.questions if None)
+            grader_model: Model for LLM grading
+
+        Returns:
+            EvalReport with all results
+        """
+        qs = questions or self.questions
+        if not qs:
+            raise ValueError("Must call generate() first or pass questions")
+
+        q_start = time.time()
+
+        if self.parallel_workers <= 1:
+            results = self._evaluate_sequential(qs, agent, grader_model)
+        else:
+            results = self._evaluate_parallel(qs, agent, grader_model)
+
+        q_elapsed = time.time() - q_start
+        grade_total = sum(r.grading_time_s for r in results)
+
+        # Build category breakdown
+        categories: dict[str, list[EvalResult]] = {}
+        for r in results:
+            categories.setdefault(r.category, []).append(r)
+
+        breakdown = []
+        for cat, cat_results in sorted(categories.items()):
+            scores = [r.overall_score for r in cat_results]
+            dim_avgs: dict[str, list[float]] = {}
+            for r in cat_results:
+                for d in r.dimensions:
+                    dim_avgs.setdefault(d.dimension, []).append(d.score)
+
+            breakdown.append(
+                CategoryBreakdown(
+                    category=cat,
+                    num_questions=len(cat_results),
+                    avg_score=sum(scores) / len(scores),
+                    min_score=min(scores),
+                    max_score=max(scores),
+                    dimension_averages={k: sum(v) / len(v) for k, v in dim_avgs.items()},
+                )
+            )
+
+        # Get memory stats
+        mem_stats: dict[str, Any] = {}
+        try:
+            mem_stats = agent.get_memory_stats()
+        except Exception:
+            pass
+
+        # Count facts delivered
+        total_facts = sum(len(t.facts) for t in (self.ground_truth.turns if self.ground_truth else []))
+
+        overall_score = sum(r.overall_score for r in results) / len(results) if results else 0.0
+
+        return EvalReport(
+            num_turns=self.num_turns,
+            num_questions=len(results),
+            total_facts_delivered=total_facts,
+            learning_time_s=0.0,  # Set by caller
+            questioning_time_s=q_elapsed,
+            grading_time_s=grade_total,
+            overall_score=overall_score,
+            category_breakdown=breakdown,
+            results=results,
+            memory_stats=mem_stats,
+        )
+
+    def _evaluate_sequential(
+        self,
+        qs: list[Question],
+        agent: Any,
+        grader_model: str,
+    ) -> list[EvalResult]:
+        """Evaluate questions sequentially (parallel_workers=1)."""
+        results: list[EvalResult] = []
+        for i, q in enumerate(qs):
+            logger.info("Question %d/%d: %s", i + 1, len(qs), q.text[:60])
+            result = self._answer_and_grade_one(i, q, agent, grader_model, len(qs))
+            results.append(result)
+        return results
+
+    def _evaluate_parallel(
+        self,
+        qs: list[Question],
+        agent: Any,
+        grader_model: str,
+    ) -> list[EvalResult]:
+        """Evaluate questions in parallel using ThreadPoolExecutor.
+
+        Each worker answers one question and grades the response. Results are
+        collected into an ordered list matching the original question order.
+
+        Solution D: Before spawning workers, snapshot all facts once and inject
+        the snapshot into the underlying LearningAgent. This ensures every thread
+        sees the same consistent set of facts without racing on get_all_facts().
+        """
+        total = len(qs)
+        results: list[EvalResult | None] = [None] * total
+        completed = [0]
+        lock = threading.Lock()
+
+        # Solution D: Pre-snapshot all facts so parallel workers don't race on
+        # get_all_facts(). The snapshot is set as _pre_snapshot_facts on the
+        # LearningAgent and consumed by _simple_retrieval() in each worker.
+        #
+        # NOTE: _MiniAgentWrapper._agent IS a LearningAgent (has _pre_snapshot_facts).
+        # _SDKAgentWrapper._agent is a GoalSeekingAgent, which does NOT have
+        # _pre_snapshot_facts, so Solution D silently no-ops for SDK paths — those
+        # workers fall back to per-thread DB queries (still correct, just not pre-snapshotted).
+        _la = None
+        if hasattr(agent, "_agent"):
+            _la = agent._agent  # may be LearningAgent (_MiniAgentWrapper) or GoalSeekingAgent (_SDKAgentWrapper)
+        elif hasattr(agent, "memory") and hasattr(agent, "_pre_snapshot_facts"):
+            _la = agent  # bare LearningAgent
+        if _la is not None and hasattr(_la, "memory") and hasattr(_la.memory, "get_all_facts"):
+            try:
+                facts_snapshot = _la.memory.get_all_facts(limit=15000)
+                _la._pre_snapshot_facts = facts_snapshot
+                logger.info(
+                    "Solution D: pre-snapshot %d facts before parallel evaluation",
+                    len(facts_snapshot),
+                )
+            except Exception as e:
+                logger.warning("Solution D: pre-snapshot failed, workers will query DB: %s", e)
+
+        logger.info(
+            "Starting parallel evaluation: %d questions, %d workers",
+            total,
+            self.parallel_workers,
+        )
+
+        def _worker(idx: int, q: Question) -> None:
+            result = self._answer_and_grade_one(idx, q, agent, grader_model, total)
+            results[idx] = result
+            with lock:
+                completed[0] += 1
+                logger.info(
+                    "Completed %d/%d questions (%.0f%%)",
+                    completed[0],
+                    total,
+                    completed[0] / total * 100,
+                )
+
+        try:
+            with ThreadPoolExecutor(max_workers=self.parallel_workers) as executor:
+                futures = {executor.submit(_worker, i, q): i for i, q in enumerate(qs)}
+                for future in as_completed(futures):
+                    exc = future.exception()
+                    if exc is not None:
+                        idx = futures[future]
+                        logger.warning("Worker for question %d failed: %s", idx + 1, exc)
+                        q = qs[idx]
+                        results[idx] = EvalResult(
+                            question_id=q.question_id,
+                            question_text=q.text,
+                            category=q.category,
+                            expected_answer=q.expected_answer,
+                            actual_answer=f"Error: {exc}",
+                            dimensions=[
+                                DimensionScore(dimension=d, score=0.0, reasoning=f"Worker error: {exc}")
+                                for d in (q.scoring_dimensions or ["factual_accuracy"])
+                            ],
+                            overall_score=0.0,
+                            grading_time_s=0.0,
+                        )
+        finally:
+            # Solution D: Clear the pre-snapshot regardless of success/failure to
+            # prevent stale data from persisting across eval invocations.
+            if _la is not None and hasattr(_la, "_pre_snapshot_facts"):
+                _la._pre_snapshot_facts = None
+
+        return [r for r in results if r is not None]
+
+    def _answer_and_grade_one(
+        self,
+        idx: int,
+        q: Question,
+        agent: Any,
+        grader_model: str,
+        total: int,
+    ) -> EvalResult:
+        """Answer a single question and grade the response. Thread-safe."""
+        logger.info("Question %d/%d: %s", idx + 1, total, q.text[:60])
+
+        try:
+            answer = agent.answer_question(q.text)
+            if isinstance(answer, tuple):
+                answer = answer[0]
+        except Exception as e:
+            logger.warning("Agent failed to answer: %s", e)
+            answer = f"Error: {e}"
+
+        grade_start = time.time()
+        dimensions = q.scoring_dimensions or ["factual_accuracy"]
+        dim_scores = _grade_multi_vote(q, answer, dimensions, grader_model, num_votes=self.grader_votes)
+        grade_time = time.time() - grade_start
+
+        overall = sum(d.score for d in dim_scores) / len(dim_scores) if dim_scores else 0.0
+
+        result = EvalResult(
+            question_id=q.question_id,
+            question_text=q.text,
+            category=q.category,
+            expected_answer=q.expected_answer,
+            actual_answer=answer if isinstance(answer, str) else str(answer),
+            dimensions=dim_scores,
+            overall_score=overall,
+            grading_time_s=grade_time,
+        )
+
+        logger.info(
+            "  Score: %.2f | Answer: %s",
+            overall,
+            (answer[:80] if isinstance(answer, str) else str(answer)[:80]) + "...",
+        )
+
+        return result
+
+    def run(
+        self,
+        agent: Any,
+        grader_model: str = "",
+        agent_factory: Any | None = None,
+    ) -> EvalReport:
+        """Run the complete evaluation: generate, learn, quiz, grade.
+
+        Args:
+            agent: Agent with learn_from_content and answer_question methods
+            grader_model: Model for LLM grading
+            agent_factory: Optional callable ``() -> agent`` for periodic restart.
+                When provided with restart_every > 0, the agent is closed and
+                reopened every N turns to cap memory growth.
+
+        Returns:
+            Complete EvalReport
+        """
+        logger.info(
+            "Starting long-horizon memory eval: %d turns, %d questions",
+            self.num_turns,
+            self.num_questions,
+        )
+
+        # Step 1: Generate data
+        self.generate()
+        logger.info(
+            "Generated %d turns, %d questions",
+            len(self.ground_truth.turns) if self.ground_truth else 0,
+            len(self.questions),
+        )
+
+        # Step 2: Feed dialogue to agent (with optional periodic restart)
+        result = self.run_dialogue(agent, agent_factory=agent_factory)
+        if isinstance(result, tuple):
+            learning_time, agent = result
+        else:
+            learning_time = result
+
+        # Step 3: Quiz and grade
+        report = self.evaluate(agent, grader_model=grader_model)
+        report.learning_time_s = learning_time
+
+        logger.info(
+            "Evaluation complete: overall=%.2f%%, learning=%.1fs, grading=%.1fs",
+            report.overall_score * 100,
+            report.learning_time_s,
+            report.grading_time_s,
+        )
+
+        return report
+
+
+def _print_report(report: EvalReport) -> None:
+    """Print a human-readable summary of the evaluation report."""
+    print("\n" + "=" * 70)
+    print("LONG-HORIZON MEMORY EVALUATION REPORT")
+    print("=" * 70)
+    print(f"Turns: {report.num_turns} | Questions: {report.num_questions}")
+    print(f"Facts delivered: {report.total_facts_delivered}")
+    print(f"Learning time: {report.learning_time_s:.1f}s")
+    print(f"Question+Grading time: {report.questioning_time_s:.1f}s")
+    print(f"\nOVERALL SCORE: {report.overall_score:.2%}")
+    print()
+
+    print("CATEGORY BREAKDOWN:")
+    print("-" * 70)
+    print(f"{'Category':<25} {'Avg':>8} {'Min':>8} {'Max':>8} {'Count':>6}")
+    print("-" * 70)
+    for cb in report.category_breakdown:
+        print(f"{cb.category:<25} {cb.avg_score:>7.2%} {cb.min_score:>7.2%} {cb.max_score:>7.2%} {cb.num_questions:>6}")
+    print("-" * 70)
+
+    print("\nDIMENSION AVERAGES BY CATEGORY:")
+    for cb in report.category_breakdown:
+        if cb.dimension_averages:
+            dims = ", ".join(f"{k}: {v:.2%}" for k, v in sorted(cb.dimension_averages.items()))
+            print(f"  {cb.category}: {dims}")
+
+    print("\nMEMORY STATS:")
+    for k, v in report.memory_stats.items():
+        print(f"  {k}: {v}")
+
+    # Show worst-performing questions
+    print("\nWORST 5 QUESTIONS:")
+    sorted_results = sorted(report.results, key=lambda r: r.overall_score)
+    for r in sorted_results[:5]:
+        print(f"  [{r.overall_score:.2%}] {r.question_text[:60]}")
+        print(f"    Expected: {r.expected_answer[:80]}")
+        print(f"    Got: {r.actual_answer[:80]}")
+        print()
+
+
+class _SDKAgentWrapper:
+    """Thin wrapper around GoalSeekingAgent for eval compatibility.
+
+    Since GoalSeekingAgent now has learn_from_content() and answer_question()
+    methods (delegating to an internal LearningAgent for LLM-based extraction),
+    this wrapper just forwards calls. It exists only to provide close() cleanup
+    and get_memory_stats() compatibility.
+    """
+
+    def __init__(self, sdk_agent: Any, answer_mode: str = "single-shot"):
+        self._agent = sdk_agent
+        self._answer_mode = answer_mode
+
+    def learn_from_content(self, content: str) -> dict[str, Any]:
+        """Forward to the SDK agent's learn_from_content method."""
+        return self._agent.learn_from_content(content)
+
+    def answer_question(self, question: str) -> str:
+        """Forward to the SDK agent's answer_question method."""
+        return self._agent.answer_question(question, answer_mode=self._answer_mode)
+
+    def get_memory_stats(self) -> dict[str, Any]:
+        """Get memory statistics."""
+        return self._agent.get_memory_stats()
+
+    def close(self) -> None:
+        """Close the underlying agent."""
+        if hasattr(self._agent, "close"):
+            try:
+                self._agent.close()
+            except Exception:
+                pass
+
+
+class _MiniAgentWrapper:
+    """Thin wrapper around LearningAgent that routes answer_mode.
+
+    When answer_mode is ``"agentic"``, calls ``answer_question_agentic()``
+    instead of the default single-shot ``answer_question()``.  All other
+    methods delegate directly to the underlying LearningAgent.
+    """
+
+    def __init__(self, learning_agent: Any, answer_mode: str = "single-shot"):
+        self._agent = learning_agent
+        self._answer_mode = answer_mode
+
+    def learn_from_content(self, content: str) -> dict[str, Any]:
+        """Forward to the LearningAgent's learn_from_content method."""
+        return self._agent.learn_from_content(content)
+
+    def answer_question(self, question: str) -> str:
+        """Route to single-shot or agentic answer based on mode."""
+        if self._answer_mode == "agentic":
+            return self._agent.answer_question_agentic(question)
+        result = self._agent.answer_question(question)
+        if isinstance(result, tuple):
+            return result[0]
+        return result
+
+    def get_memory_stats(self) -> dict[str, Any]:
+        """Get memory statistics."""
+        return self._agent.get_memory_stats()
+
+    def flush_memory(self) -> None:
+        """Forward flush_memory to underlying agent."""
+        if hasattr(self._agent, "flush_memory"):
+            self._agent.flush_memory()
+
+    def close(self) -> None:
+        """Close the underlying agent."""
+        if hasattr(self._agent, "close"):
+            try:
+                self._agent.close()
+            except Exception:
+                pass
+
+
+def _save_dialogue_json(gt: GroundTruth, path: Path) -> None:
+    """Save generated dialogue to JSON for subprocess segment workers."""
+    turns_data = []
+    for t in gt.turns:
+        turns_data.append(
+            {
+                "turn_number": t.turn_number,
+                "content": t.content,
+                "block": t.block,
+                "block_name": t.block_name,
+                "facts": t.facts if hasattr(t, "facts") else [],
+            }
+        )
+    with open(path, "w") as f:
+        json.dump(turns_data, f)
+    logger.info("Saved dialogue (%d turns) to %s", len(turns_data), path)
+
+
+def _load_dialogue_slice(path: Path, start: int, end: int) -> list[dict[str, Any]]:
+    """Load a slice of turns from a dialogue JSON file.
+
+    Args:
+        path: Path to dialogue JSON file
+        start: Start index (inclusive, 0-based)
+        end: End index (exclusive)
+
+    Returns:
+        List of turn dicts with 'content' key
+    """
+    with open(path) as f:
+        all_turns = json.load(f)
+    return all_turns[start:end]
+
+
+def _count_facts_in_db(db_path: Path) -> int:
+    """Count semantic facts in the Kuzu DB for early failure detection."""
+    try:
+        import kuzu  # type: ignore[import-not-found]
+
+        kuzu_path = db_path / "kuzu_db"
+        if not kuzu_path.exists():
+            kuzu_path = db_path
+        db = kuzu.Database(str(kuzu_path))
+        conn = kuzu.Connection(db)
+        result = conn.execute("MATCH (n:SemanticMemory) RETURN count(n)")
+        count = 0
+        if result.has_next():
+            count = result.get_next()[0]
+        del conn, db
+        return count
+    except Exception as e:
+        logger.warning("Could not count facts in DB at %s: %s", db_path, e)
+        return 0
+
+
+def _run_segmented_learning(args: argparse.Namespace) -> None:
+    """Orchestrate segmented learning by spawning subprocess workers.
+
+    For each segment of --segment-size turns, spawns a new Python process
+    that loads the dialogue slice, learns it, and exits. This frees ALL
+    native memory (Kuzu C++, aiohttp) between segments.
+    """
+    import subprocess
+    import sys
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    db_path = output_dir / "memory_db"
+    # Pre-create as directory so HierarchicalMemory uses db_path/kuzu_db
+    # (not a flat file), keeping consistent with --load-db expectations.
+    db_path.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Generate dialogue and save to JSON
+    logger.info("Generating %d-turn dialogue (seed=%d)...", args.turns, args.seed)
+    gt = generate_dialogue(num_turns=args.turns, seed=args.seed)
+    dialogue_path = output_dir / "dialogue.json"
+    _save_dialogue_json(gt, dialogue_path)
+
+    # Step 2: Run learning in segments
+    total = args.turns
+    seg_size = args.segment_size
+    num_segments = (total + seg_size - 1) // seg_size
+    agent_model = args.model or os.environ.get("EVAL_MODEL", "claude-opus-4-6")
+
+    logger.info(
+        "Segmented learning: %d turns in %d segments of %d",
+        total,
+        num_segments,
+        seg_size,
+    )
+
+    segment_start_time = time.time()
+    failed_segments: list[int] = []
+    for seg_idx in range(num_segments):
+        seg_start = seg_idx * seg_size
+        seg_end = min(seg_start + seg_size, total)
+
+        logger.info(
+            "[Segment %d/%d] turns %d:%d",
+            seg_idx + 1,
+            num_segments,
+            seg_start,
+            seg_end,
+        )
+
+        # Build subprocess command reusing this module
+        cmd = [
+            sys.executable,
+            "-m",
+            "amplihack_eval.eval.long_horizon_memory",
+            "--turns",
+            str(total),
+            "--seed",
+            str(args.seed),
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            agent_model,
+            "--sdk",
+            args.sdk,
+            "--dialogue-json",
+            str(dialogue_path),
+            "--turns-slice",
+            f"{seg_start}:{seg_end}",
+            "--skip-questions",
+        ]
+        if args.use_hierarchical:
+            cmd.append("--use-hierarchical")
+        if args.flush_every > 0:
+            cmd.extend(["--flush-every", str(args.flush_every)])
+        if getattr(args, "memory_type", "auto") != "auto":
+            cmd.extend(["--memory-type", args.memory_type])
+
+        # Retry once on failure, then skip the segment
+        max_attempts = 2
+        succeeded = False
+        for attempt in range(1, max_attempts + 1):
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode == 0:
+                succeeded = True
+                break
+            logger.warning(
+                "Segment %d attempt %d/%d failed (exit %d):\nstderr: %s",
+                seg_idx + 1,
+                attempt,
+                max_attempts,
+                result.returncode,
+                result.stderr[-500:] if result.stderr else "",
+            )
+
+        if succeeded:
+            logger.info("[Segment %d/%d] complete", seg_idx + 1, num_segments)
+        else:
+            logger.error(
+                "Segment %d failed after %d attempts, skipping turns %d:%d",
+                seg_idx + 1,
+                max_attempts,
+                seg_start,
+                seg_end,
+            )
+            failed_segments.append(seg_idx + 1)
+
+        # Early failure detection: after first segment completes, verify
+        # facts were actually stored. Catches schema mismatches silently
+        # swallowing store_fact errors (issue #2655).
+        if seg_idx == 0 and succeeded and args.sdk == "mini":
+            fact_count = _count_facts_in_db(db_path)
+            if fact_count == 0:
+                raise RuntimeError(
+                    f"ABORTING: First segment completed but 0 facts stored "
+                    f"in DB at {db_path}. This indicates a fundamental issue "
+                    f"with the memory backend (schema mismatch, silent store "
+                    f"failures, or wrong db_path). Check --memory-type "
+                    f"setting and ensure the DB schema is compatible."
+                )
+            logger.info(
+                "Early check: %d facts after first segment -- storage OK",
+                fact_count,
+            )
+
+    if failed_segments:
+        logger.warning(
+            "%d of %d segments failed and were skipped: %s",
+            len(failed_segments),
+            num_segments,
+            failed_segments,
+        )
+
+    learning_elapsed = time.time() - segment_start_time
+    logger.info(
+        "All %d segments complete in %.1fs. DB at %s",
+        num_segments,
+        learning_elapsed,
+        db_path,
+    )
+
+    # Step 3: Run questioning phase with the accumulated DB
+    logger.info("Starting questioning phase with %d questions...", args.questions)
+    questions_cmd = [
+        sys.executable,
+        "-m",
+        "amplihack_eval.eval.long_horizon_memory",
+        "--turns",
+        str(total),
+        "--questions",
+        str(args.questions),
+        "--seed",
+        str(args.seed),
+        "--output-dir",
+        str(output_dir),
+        "--model",
+        agent_model,
+        "--grader-model",
+        args.grader_model or "",
+        "--sdk",
+        args.sdk,
+        "--grader-votes",
+        str(args.grader_votes),
+        "--parallel-workers",
+        str(args.parallel_workers),
+        "--skip-learning",
+        "--load-db",
+        str(db_path),
+    ]
+    if args.use_hierarchical:
+        questions_cmd.append("--use-hierarchical")
+    if args.verbose:
+        questions_cmd.append("--verbose")
+    answer_mode = getattr(args, "answer_mode", "single-shot")
+    if answer_mode != "single-shot":
+        questions_cmd.extend(["--answer-mode", answer_mode])
+    if getattr(args, "memory_type", "auto") != "auto":
+        questions_cmd.extend(["--memory-type", args.memory_type])
+
+    result = subprocess.run(questions_cmd)
+    if result.returncode != 0:
+        raise RuntimeError(f"Questioning phase failed with exit code {result.returncode}")
+
+
+def _run_segment_worker(args: argparse.Namespace) -> None:
+    """Subprocess worker: learn a slice of turns from a dialogue JSON, then exit.
+
+    This is invoked by _run_segmented_learning for each segment. The worker:
+    1. Loads turn slice from the dialogue JSON
+    2. Creates an agent connected to the shared DB
+    3. Learns the slice
+    4. Closes the agent and exits (freeing ALL native memory)
+    """
+    # Parse slice
+    parts = args.turns_slice.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"--turns-slice must be START:END, got: {args.turns_slice}")
+    slice_start, slice_end = int(parts[0]), int(parts[1])
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    db_path = output_dir / "memory_db"
+    agent_model = args.model or os.environ.get("EVAL_MODEL", "claude-opus-4-6")
+
+    # Load dialogue slice from JSON
+    dialogue_path = Path(args.dialogue_json) if args.dialogue_json else output_dir / "dialogue.json"
+    if not dialogue_path.exists():
+        raise FileNotFoundError(f"Dialogue JSON not found: {dialogue_path}")
+
+    turns = _load_dialogue_slice(dialogue_path, slice_start, slice_end)
+    logger.info(
+        "Segment worker: turns %d:%d (%d turns), db=%s",
+        slice_start,
+        slice_end,
+        len(turns),
+        db_path,
+    )
+
+    # Create agent
+    from amplihack.agents.goal_seeking.runtime_factory import create_goal_agent_runtime
+
+    agent_name = "long_horizon_eval"
+    agent = create_goal_agent_runtime(
+        agent_name=agent_name,
+        sdk=args.sdk,
+        model=agent_model,
+        storage_path=db_path,
+        use_hierarchical=args.use_hierarchical,
+        memory_type=getattr(args, "memory_type", "auto"),
+    )
+
+    # Learn the slice
+    flush_every = args.flush_every if hasattr(args, "flush_every") else 0
+    can_flush = flush_every > 0 and hasattr(agent, "flush_memory")
+
+    try:
+        for i, turn in enumerate(turns):
+            content = turn.get("content", "")
+            if not content or not content.strip():
+                continue
+            try:
+                agent.learn_from_content(content)
+            except Exception as e:
+                logger.warning(
+                    "Failed to learn turn %d (global %d): %s",
+                    i,
+                    slice_start + i,
+                    e,
+                )
+
+            if can_flush and (i + 1) % flush_every == 0:
+                try:
+                    agent.flush_memory()  # type: ignore[union-attr]
+                except Exception:
+                    pass
+
+            if (i + 1) % 50 == 0 or i == len(turns) - 1:
+                logger.info(
+                    "  Turn %d/%d (global %d)",
+                    i + 1,
+                    len(turns),
+                    slice_start + i + 1,
+                )
+    finally:
+        try:
+            agent.close()
+        except Exception:
+            pass
+
+    logger.info("Segment worker complete: turns %d:%d", slice_start, slice_end)
+
+
+def main() -> None:
+    """CLI entry point for long-horizon memory evaluation."""
+    parser = argparse.ArgumentParser(description="Long-horizon memory stress test for goal-seeking agents")
+    parser.add_argument("--turns", type=int, default=1000, help="Number of dialogue turns (default: 1000)")
+    parser.add_argument("--questions", type=int, default=100, help="Number of quiz questions (default: 100)")
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=os.path.join(tempfile.gettempdir(), "memory-eval"),
+        help="Output directory for results",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="",
+        help="LLM model for the agent (default: env EVAL_MODEL or claude-opus-4-6)",
+    )
+    parser.add_argument(
+        "--grader-model",
+        type=str,
+        default="",
+        help="LLM model for grading (default: env GRADER_MODEL or claude-opus-4-6)",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility")
+    parser.add_argument(
+        "--use-hierarchical",
+        action="store_true",
+        default=True,
+        help="Use hierarchical memory (default: True)",
+    )
+    parser.add_argument(
+        "--grader-votes",
+        type=int,
+        default=3,
+        help="Number of grading votes per question for multi-vote stability (default: 3)",
+    )
+    parser.add_argument(
+        "--sdk",
+        type=str,
+        default="mini",
+        choices=["mini", "claude", "copilot", "microsoft"],
+        help="SDK to use for the agent (default: mini = LearningAgent directly)",
+    )
+    parser.add_argument(
+        "--memory-type",
+        type=str,
+        default="auto",
+        choices=["auto", "hierarchical", "cognitive"],
+        help="Force memory backend: auto (prefer cognitive if available), "
+        "hierarchical (FlatRetrieverAdapter), cognitive (CognitiveAdapter). Default: auto.",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--skip-learning",
+        action="store_true",
+        default=False,
+        help="Skip the learning phase; use with --load-db to test questions against an existing memory DB",
+    )
+    parser.add_argument(
+        "--load-db",
+        type=str,
+        default="",
+        help="Path to an existing memory DB directory to load instead of creating a new one. "
+        "Copies the DB to the output directory before running.",
+    )
+    parser.add_argument(
+        "--parallel-workers",
+        type=int,
+        default=10,
+        help="Number of parallel workers for question answering/grading (1=sequential, max 20, default: 10)",
+    )
+    parser.add_argument(
+        "--flush-every",
+        type=int,
+        default=100,
+        help="Flush agent memory every N turns to cap cache growth. "
+        "0 disables. Agent must expose flush_memory() (default: 100).",
+    )
+    parser.add_argument(
+        "--restart-every",
+        type=int,
+        default=0,
+        help="Restart agent every N turns to free memory via del + gc.collect. "
+        "0 disables. Requires agent recreation (default: 0).",
+    )
+    parser.add_argument(
+        "--segment-size",
+        type=int,
+        default=0,
+        help="Run learning phase in subprocess segments of N turns each. "
+        "Each segment runs in a NEW Python process so native memory (Kuzu C++, "
+        "aiohttp) is fully freed between segments. 0 disables (default: 0).",
+    )
+    parser.add_argument(
+        "--turns-slice",
+        type=str,
+        default="",
+        help="Internal: learn only turns START:END from a pre-generated dialogue JSON. "
+        "Format: START:END (0-indexed, exclusive end). Used by --segment-size orchestrator.",
+    )
+    parser.add_argument(
+        "--dialogue-json",
+        type=str,
+        default="",
+        help="Internal: path to pre-generated dialogue JSON file. "
+        "Used with --turns-slice for subprocess segment workers.",
+    )
+    parser.add_argument(
+        "--skip-questions",
+        action="store_true",
+        default=False,
+        help="Skip the questioning phase (learn only). Used by segment workers.",
+    )
+    parser.add_argument(
+        "--answer-mode",
+        type=str,
+        default="single-shot",
+        choices=["single-shot", "agentic"],
+        help="Answer mode: single-shot (default, proven at 97.8%%) uses optimized "
+        "intent/retrieve/synthesize pipeline. agentic uses iterative "
+        "PERCEIVE->REASON->ACT->LEARN loop with tool use.",
+    )
+
+    args = parser.parse_args()
+
+    # Setup logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    # MODE 1: Segmented orchestrator -- delegates learning to subprocess workers
+    if args.segment_size > 0 and not args.turns_slice:
+        _run_segmented_learning(args)
+        return
+
+    # MODE 2: Subprocess worker -- learn a slice of turns, then exit
+    if args.turns_slice:
+        _run_segment_worker(args)
+        return
+
+    # MODE 3: Normal (original behavior)
+
+    # Create output directory
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set model if provided
+    agent_model = args.model or os.environ.get("EVAL_MODEL", "claude-opus-4-6")
+
+    # Create agent based on --sdk choice
+    logger.info(
+        "Creating agent with sdk=%s, model=%s, hierarchical=%s",
+        args.sdk,
+        agent_model,
+        args.use_hierarchical,
+    )
+
+    db_path = output_dir / "memory_db"
+
+    # Copy saved DB if --load-db is specified
+    if args.load_db:
+        import shutil
+
+        src_db = Path(args.load_db).resolve()
+        if not src_db.exists():
+            raise FileNotFoundError(f"--load-db path does not exist: {src_db}")
+        # Skip copy when src and dst are the same (e.g. segment orchestrator)
+        if src_db != db_path.resolve():
+            if db_path.exists():
+                if db_path.is_dir():
+                    shutil.rmtree(db_path)
+                else:
+                    db_path.unlink()
+            shutil.copytree(src_db, db_path)
+            logger.info("Loaded existing memory DB from %s -> %s", src_db, db_path)
+        else:
+            logger.info("Using existing memory DB in-place at %s", db_path)
+
+    # Determine agent name -- match the name used when the DB was created.
+    # When loading a pre-built DB, detect agent_id from the DB to avoid mismatch.
+    agent_name = "long_horizon_eval"
+    if args.load_db:
+        try:
+            import kuzu  # type: ignore[import-not-found]
+
+            _detect_db = kuzu.Database(str(db_path / "kuzu_db"))
+            _detect_conn = kuzu.Connection(_detect_db)
+            _result = _detect_conn.execute("MATCH (e:EpisodicMemory) RETURN DISTINCT e.agent_id LIMIT 1")
+            if _result.has_next():
+                agent_name = _result.get_next()[0]
+                logger.info("Detected agent_id from DB: %s", agent_name)
+            del _detect_conn, _detect_db
+        except Exception as _e:
+            logger.warning("Could not detect agent_id from DB: %s", _e)
+            agent_name = "long_horizon_eval_learning"
+
+    def _create_agent() -> Any:
+        """Factory to create (or recreate) the eval agent."""
+        from amplihack.agents.goal_seeking.runtime_factory import create_goal_agent_runtime
+
+        return create_goal_agent_runtime(
+            agent_name=agent_name,
+            sdk=args.sdk,
+            model=agent_model,
+            storage_path=db_path,
+            use_hierarchical=args.use_hierarchical,
+            memory_type=getattr(args, "memory_type", "auto"),
+            answer_mode=getattr(args, "answer_mode", "single-shot"),
+        )
+
+    agent = _create_agent()
+
+    try:
+        # Run evaluation
+        evaluator = LongHorizonMemoryEval(
+            num_turns=args.turns,
+            num_questions=args.questions,
+            seed=args.seed,
+            grader_votes=args.grader_votes,
+            parallel_workers=args.parallel_workers,
+            flush_every=args.flush_every,
+            restart_every=args.restart_every,
+        )
+
+        # Provide agent_factory when restart_every is set
+        agent_factory = _create_agent if args.restart_every > 0 else None
+
+        if args.skip_learning:
+            # Skip learning: only generate data + questions, then quiz
+            evaluator.generate()
+            logger.info(
+                "SKIP-LEARNING mode: generated %d questions, using existing memory DB",
+                len(evaluator.questions),
+            )
+            report = evaluator.evaluate(agent, grader_model=args.grader_model)
+            report.learning_time_s = 0.0
+        elif args.skip_questions:
+            # Learn only, no questions (used by segment workers calling normal mode)
+            evaluator.generate()
+            evaluator.run_dialogue(agent, agent_factory=agent_factory)
+            logger.info("Learning-only mode complete")
+            return
+        else:
+            report = evaluator.run(agent, grader_model=args.grader_model, agent_factory=agent_factory)
+
+        # Print report
+        _print_report(report)
+
+        # Save JSON report
+        report_path = output_dir / "report.json"
+        with open(report_path, "w") as f:
+            json.dump(report.to_dict(), f, indent=2)
+        logger.info("Report saved to %s", report_path)
+
+        # Save ground truth for analysis
+        if evaluator.ground_truth:
+            gt_path = output_dir / "ground_truth.json"
+            gt_data = {
+                "num_turns": len(evaluator.ground_truth.turns),
+                "turns_with_facts": sum(1 for t in evaluator.ground_truth.turns if t.facts),
+                "total_facts": sum(len(t.facts) for t in evaluator.ground_truth.turns),
+                "current_values": evaluator.ground_truth.current_values,
+                "superseded_count": sum(len(v) for v in evaluator.ground_truth.superseded_values.values()),
+                "block_distribution": {},
+            }
+            for t in evaluator.ground_truth.turns:
+                gt_data["block_distribution"][t.block_name] = gt_data["block_distribution"].get(t.block_name, 0) + 1
+            with open(gt_path, "w") as f:
+                json.dump(gt_data, f, indent=2)
+            logger.info("Ground truth saved to %s", gt_path)
+
+    finally:
+        agent.close()
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "LongHorizonMemoryEval",
+    "EvalResult",
+    "EvalReport",
+    "CategoryBreakdown",
+    "DimensionScore",
+    "_deterministic_grade",
+    "_grade_hybrid",
+    "_grade_multi_vote",
+    "_save_dialogue_json",
+    "_load_dialogue_slice",
+]

--- a/src/amplihack_eval/eval/long_horizon_self_improve.py
+++ b/src/amplihack_eval/eval/long_horizon_self_improve.py
@@ -1,0 +1,817 @@
+"""Self-improvement loop for long-horizon memory evaluation.
+
+Implements the full automated self-improvement cycle:
+  EVAL -> ANALYZE -> PROPOSE -> CHALLENGE -> VOTE -> APPLY -> RE-EVAL -> DECIDE
+
+Each iteration:
+1. Run long-horizon eval to get per-category scores
+2. Identify worst category
+3. Propose a patch using LLM (patch_proposer)
+4. Challenge the proposal via devil's advocate (reviewer_voting)
+5. Vote on the proposal with 3 reviewer perspectives (reviewer_voting)
+6. If accepted: apply patch, git commit
+7. Re-eval to compare
+8. If regression: auto-revert, log, continue
+9. If improvement: keep, log, continue
+
+Philosophy:
+- Measure first, change second
+- Every patch is challenged and reviewed before application
+- Auto-revert on regression protects existing quality
+- Full history prevents repeating failed fixes
+- Log everything for reproducibility
+
+Public API:
+    LongHorizonSelfImproveRunner: Main runner class
+    LongHorizonRunnerConfig: Configuration dataclass
+    CategoryAnalysis: Per-category failure analysis
+
+Usage:
+    python -m amplihack_eval.eval.long_horizon_self_improve --turns 100 --questions 20
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from amplihack_eval.self_improve.patch_proposer import PatchHistory, propose_patch
+from amplihack_eval.self_improve.reviewer_voting import (
+    challenge_proposal,
+    review_result_to_dict,
+    vote_on_proposal,
+)
+
+from .long_horizon_memory import (
+    EvalReport,
+    LongHorizonMemoryEval,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CategoryAnalysis:
+    """Analysis of failures in a single question category.
+
+    Attributes:
+        category: Category name (e.g., "needle_in_haystack")
+        avg_score: Average score for this category
+        num_questions: Number of questions in this category
+        failed_questions: Questions scoring below threshold
+        bottleneck: Identified system component causing failures
+        suggested_fix: Suggested improvement
+    """
+
+    category: str
+    avg_score: float
+    num_questions: int
+    failed_questions: list[dict[str, Any]] = field(default_factory=list)
+    bottleneck: str = ""
+    suggested_fix: str = ""
+
+
+@dataclass
+class LongHorizonRunnerConfig:
+    """Configuration for the long-horizon self-improvement runner."""
+
+    num_turns: int = 100
+    num_questions: int = 20
+    seed: int = 42
+    max_iterations: int = 3
+    failure_threshold: float = 0.7  # Score below this = failure
+    regression_threshold: float = 5.0  # Max regression (pp) before auto-revert
+    use_multi_agent: bool = False  # Use MultiAgentLearningAgent
+    output_dir: str = "/tmp/long-horizon-self-improve"
+    agent_model: str = ""
+    grader_model: str = ""
+
+
+@dataclass
+class IterationResult:
+    """Result of one improvement iteration."""
+
+    iteration: int
+    report: dict[str, Any]
+    category_analyses: list[dict[str, Any]]
+    improvements_applied: list[str]
+    patch_proposal: dict[str, Any] | None = None
+    review_result: dict[str, Any] | None = None
+    post_scores: dict[str, float] | None = None
+    reverted: bool = False
+    revert_reason: str = ""
+    duration_seconds: float = 0.0
+
+
+@dataclass
+class RunnerResult:
+    """Complete self-improvement run result."""
+
+    config: dict[str, Any]
+    iterations: list[IterationResult]
+    score_progression: list[float]
+    category_progression: dict[str, list[float]]
+    total_duration_seconds: float
+
+
+def _analyze_categories(report: EvalReport, threshold: float) -> list[CategoryAnalysis]:
+    """Analyze failures by question category.
+
+    For each category, identifies:
+    - Average score and failure rate
+    - Specific questions that failed
+    - The system component most likely causing the failure
+    - A suggested fix
+
+    Args:
+        report: The evaluation report
+        threshold: Score below which a question is considered failed
+
+    Returns:
+        List of CategoryAnalysis sorted by average score (worst first)
+    """
+    analyses: list[CategoryAnalysis] = []
+
+    for cb in report.category_breakdown:
+        # Find failed questions in this category
+        failed = []
+        for r in report.results:
+            if r.category == cb.category and r.overall_score < threshold:
+                failed.append(
+                    {
+                        "question_id": r.question_id,
+                        "question_text": r.question_text,
+                        "expected_answer": r.expected_answer[:200],
+                        "actual_answer": r.actual_answer[:200],
+                        "score": r.overall_score,
+                        "dimensions": {d.dimension: d.score for d in r.dimensions},
+                    }
+                )
+
+        # Identify bottleneck based on category and failure patterns
+        bottleneck, suggested_fix = _diagnose_bottleneck(cb.category, failed, cb.dimension_averages)
+
+        analyses.append(
+            CategoryAnalysis(
+                category=cb.category,
+                avg_score=cb.avg_score,
+                num_questions=cb.num_questions,
+                failed_questions=failed,
+                bottleneck=bottleneck,
+                suggested_fix=suggested_fix,
+            )
+        )
+
+    # Sort by score (worst first)
+    analyses.sort(key=lambda a: a.avg_score)
+    return analyses
+
+
+def _diagnose_bottleneck(
+    category: str,
+    failed_questions: list[dict[str, Any]],
+    dimension_averages: dict[str, float],
+) -> tuple[str, str]:
+    """Diagnose the system component causing failures in a category.
+
+    Args:
+        category: Question category
+        failed_questions: List of failed question details
+        dimension_averages: Average scores per dimension
+
+    Returns:
+        Tuple of (bottleneck component, suggested fix)
+    """
+    if not failed_questions:
+        return "", ""
+
+    # Analyze dimension scores to find the weakest link
+    worst_dim = ""
+    worst_score = 1.0
+    for dim, score in dimension_averages.items():
+        if score < worst_score:
+            worst_score = score
+            worst_dim = dim
+
+    # Category-specific diagnosis
+    if category == "needle_in_haystack":
+        return (
+            "retrieval:keyword_search",
+            "Entity-centric indexing: store entity names as indexed fields "
+            "so retrieval can find facts about specific people/projects "
+            "without relying on keyword overlap. Scale similarity window.",
+        )
+
+    if category == "meta_memory":
+        return (
+            "retrieval:aggregation",
+            "Add Cypher aggregation queries: route 'how many' / 'list all' "
+            "questions to COUNT/DISTINCT queries on the graph instead of "
+            "text search.",
+        )
+
+    if category == "source_attribution":
+        if worst_dim == "source_attribution":
+            return (
+                "retrieval:source_tracking",
+                "Improve source label propagation: ensure DERIVES_FROM edges "
+                "are created for all facts, and source_label is included in "
+                "retrieval results.",
+            )
+        return (
+            "synthesis:source_instructions",
+            "Add stronger source attribution instructions to the synthesis prompt.",
+        )
+
+    if category == "temporal_evolution":
+        return (
+            "retrieval:temporal_ordering",
+            "Improve temporal metadata coverage: ensure all temporally-ordered "
+            "facts have temporal_index metadata for chronological sorting.",
+        )
+
+    if category == "cross_reference":
+        return (
+            "retrieval:graph_traversal",
+            "Improve graph traversal: expand SIMILAR_TO edge hop depth to "
+            "connect facts across different information blocks.",
+        )
+
+    if category == "numerical_precision":
+        return (
+            "synthesis:arithmetic",
+            "Improve arithmetic validation: ensure calculate tool is used "
+            "for all mathematical operations in the synthesis step.",
+        )
+
+    if category == "distractor_resistance":
+        return (
+            "retrieval:confidence_weighting",
+            "Improve confidence weighting: facts from distractor blocks "
+            "should have lower confidence and be deprioritized in retrieval.",
+        )
+
+    # Generic diagnosis based on worst dimension
+    if worst_dim == "factual_accuracy":
+        return "retrieval:coverage", "Increase retrieval coverage (broader search window)"
+    if worst_dim == "specificity":
+        return "retrieval:precision", "Improve retrieval precision (better reranking)"
+    if worst_dim == "temporal_awareness":
+        return "retrieval:temporal", "Add temporal metadata to retrieval"
+    if worst_dim == "source_attribution":
+        return "retrieval:provenance", "Improve source tracking in graph"
+    if worst_dim == "confidence_calibration":
+        return "synthesis:calibration", "Improve confidence expression in answers"
+
+    return "unknown", "Manual investigation needed"
+
+
+def _extract_category_scores(report: EvalReport) -> dict[str, float]:
+    """Extract per-category scores from a report.
+
+    Args:
+        report: EvalReport instance
+
+    Returns:
+        Dict mapping category -> avg_score
+    """
+    scores: dict[str, float] = {}
+    for cb in report.category_breakdown:
+        scores[cb.category] = cb.avg_score
+    if scores:
+        scores["overall"] = report.overall_score
+    return scores
+
+
+def detect_regression(
+    baseline_scores: dict[str, float],
+    post_scores: dict[str, float],
+    threshold: float = 5.0,
+) -> tuple[bool, str, float]:
+    """Detect if any category regressed beyond the threshold.
+
+    A regression occurs when a category drops more than threshold percentage
+    points WITHOUT a compensating gain of the same magnitude in another
+    category.
+
+    Args:
+        baseline_scores: Pre-change per-category scores
+        post_scores: Post-change per-category scores
+        threshold: Maximum allowed regression in percentage points
+
+    Returns:
+        Tuple of (has_regression, worst_category, worst_regression_pp)
+    """
+    max_regression_pp = 0.0
+    worst_category = ""
+    max_gain_pp = 0.0
+
+    for cat in baseline_scores:
+        if cat == "overall":
+            continue
+        if cat in post_scores:
+            delta_pp = (baseline_scores[cat] - post_scores[cat]) * 100.0
+            if delta_pp > max_regression_pp:
+                max_regression_pp = delta_pp
+                worst_category = cat
+            if delta_pp < 0:
+                max_gain_pp = max(max_gain_pp, abs(delta_pp))
+
+    # Regression is only flagged if the drop exceeds threshold AND
+    # there is no compensating gain of equal magnitude
+    has_regression = max_regression_pp > threshold and max_gain_pp < threshold
+
+    return has_regression, worst_category, max_regression_pp
+
+
+def _git_revert_last_commit(project_root: Path) -> bool:
+    """Revert the last git commit (used for auto-reverting regressive patches).
+
+    Args:
+        project_root: Root directory of the git repository
+
+    Returns:
+        True if revert succeeded, False otherwise
+    """
+    try:
+        result = subprocess.run(
+            ["git", "revert", "--no-commit", "HEAD"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            subprocess.run(
+                ["git", "commit", "-m", "auto-revert: regression detected"],
+                cwd=str(project_root),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return True
+        logger.error("Git revert failed: %s", result.stderr)
+        return False
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.error("Git revert error: %s", e)
+        return False
+
+
+def run_long_horizon_self_improve(
+    config: LongHorizonRunnerConfig,
+    llm_call: Any | None = None,
+    project_root: Path | None = None,
+) -> RunnerResult:
+    """Run the long-horizon self-improvement loop with automated patch proposal and review.
+
+    For each iteration:
+    1. Run eval -> get per-category scores
+    2. Identify worst category
+    3. patch_proposer.propose(eval_results, history) -> PatchProposal
+    4. challenge(proposal) -> ChallengeResponse
+    5. reviewer_voting.vote(proposal, challenge_response) -> ReviewResult
+    6. If accepted: apply patch, git commit
+    7. Re-eval -> compare
+    8. If regression: auto-revert, log, continue to next iteration
+    9. If improvement: keep, log, continue
+
+    Args:
+        config: Runner configuration
+        llm_call: Optional LLM callable for patch proposal and review.
+                  Signature: (prompt: str) -> str. If None, stub logic is used.
+        project_root: Optional project root path for reading source files.
+
+    Returns:
+        RunnerResult with all iteration details
+    """
+    import os
+
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if project_root is None:
+        project_root = Path(".")
+
+    iterations: list[IterationResult] = []
+    score_progression: list[float] = []
+    category_progression: dict[str, list[float]] = {}
+    patch_history = PatchHistory()
+    start_time = time.time()
+
+    agent_model = config.agent_model or os.environ.get("EVAL_MODEL", "claude-opus-4-6")
+
+    print("=" * 70)
+    print("LONG-HORIZON SELF-IMPROVEMENT RUNNER (with A/B Reviewer Voting)")
+    print("=" * 70)
+    print(f"Turns: {config.num_turns}")
+    print(f"Questions: {config.num_questions}")
+    print(f"Max iterations: {config.max_iterations}")
+    print(f"Failure threshold: {config.failure_threshold:.0%}")
+    print(f"Regression threshold: {config.regression_threshold:.1f}pp")
+    print(f"Multi-agent: {config.use_multi_agent}")
+    print(f"Agent model: {agent_model}")
+    print(f"Output: {config.output_dir}")
+    print("=" * 70)
+
+    for iteration in range(1, config.max_iterations + 1):
+        iter_start = time.time()
+        iter_dir = output_dir / f"iteration_{iteration}"
+        iter_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"\n{'=' * 70}")
+        print(f"ITERATION {iteration}/{config.max_iterations}")
+        print(f"{'=' * 70}")
+
+        # Create agent
+        db_path = iter_dir / "memory_db"
+        if config.use_multi_agent:
+            from amplihack.agents.goal_seeking.sub_agents import MultiAgentLearningAgent
+
+            agent = MultiAgentLearningAgent(
+                agent_name=f"lh_eval_iter{iteration}_{int(time.time())}",
+                model=agent_model,
+                storage_path=db_path,
+                use_hierarchical=True,
+            )
+        else:
+            from amplihack.agents.goal_seeking.learning_agent import LearningAgent
+
+            agent = LearningAgent(
+                agent_name=f"lh_eval_iter{iteration}_{int(time.time())}",
+                model=agent_model,
+                storage_path=db_path,
+                use_hierarchical=True,
+            )
+
+        try:
+            # Phase 1: EVAL - Run long-horizon evaluation
+            print("\n[Phase 1/8] EVAL - Running long-horizon evaluation...")
+            evaluator = LongHorizonMemoryEval(
+                num_turns=config.num_turns,
+                num_questions=config.num_questions,
+                seed=config.seed,
+            )
+            report = evaluator.run(agent, grader_model=config.grader_model)
+
+            print(f"  Overall score: {report.overall_score:.2%}")
+            score_progression.append(report.overall_score)
+            baseline_scores = _extract_category_scores(report)
+
+            # Category scores
+            for cb in report.category_breakdown:
+                if cb.category not in category_progression:
+                    category_progression[cb.category] = []
+                category_progression[cb.category].append(cb.avg_score)
+                print(f"  {cb.category}: {cb.avg_score:.2%}")
+
+            # Phase 2: ANALYZE - Classify failures by category
+            print("\n[Phase 2/8] ANALYZE - Classifying failures by category...")
+            analyses = _analyze_categories(report, config.failure_threshold)
+
+            failing_categories = [a for a in analyses if a.avg_score < config.failure_threshold]
+            print(f"  Categories below {config.failure_threshold:.0%}: {len(failing_categories)}")
+
+            for a in analyses:
+                status = "FAIL" if a.avg_score < config.failure_threshold else "PASS"
+                print(f"  [{status}] {a.category}: {a.avg_score:.2%}")
+                if a.bottleneck:
+                    print(f"    Bottleneck: {a.bottleneck}")
+                    print(f"    Fix: {a.suggested_fix[:80]}...")
+
+            analyses_dicts = [
+                {
+                    "category": a.category,
+                    "avg_score": a.avg_score,
+                    "num_questions": a.num_questions,
+                    "bottleneck": a.bottleneck,
+                    "suggested_fix": a.suggested_fix,
+                    "failed_questions": a.failed_questions,
+                }
+                for a in analyses
+            ]
+
+            # Early exit if all categories pass
+            if not failing_categories:
+                print("  All categories above threshold. Stopping.")
+                iter_duration = time.time() - iter_start
+                iterations.append(
+                    IterationResult(
+                        iteration=iteration,
+                        report=report.to_dict(),
+                        category_analyses=analyses_dicts,
+                        improvements_applied=[],
+                        duration_seconds=iter_duration,
+                    )
+                )
+                break
+
+            # Phase 3: PROPOSE - Generate patch for worst category
+            worst = failing_categories[0]
+            print(f"\n[Phase 3/8] PROPOSE - Generating patch for '{worst.category}'...")
+            proposal = propose_patch(
+                category=worst.category,
+                category_score=worst.avg_score,
+                failed_questions=worst.failed_questions,
+                bottleneck=worst.bottleneck,
+                suggested_fix=worst.suggested_fix,
+                history=patch_history,
+                project_root=project_root,
+                llm_call=llm_call,
+            )
+            print(f"  Target: {proposal.target_file}")
+            print(f"  Hypothesis: {proposal.hypothesis[:80]}...")
+            print(f"  Confidence: {proposal.confidence:.0%}")
+
+            proposal_dict = {
+                "target_file": proposal.target_file,
+                "hypothesis": proposal.hypothesis,
+                "description": proposal.description,
+                "confidence": proposal.confidence,
+                "risk_assessment": proposal.risk_assessment,
+                "expected_impact": proposal.expected_impact,
+                "diff_length": len(proposal.diff),
+            }
+
+            # Phase 4: CHALLENGE - Devil's advocate
+            print("\n[Phase 4/8] CHALLENGE - Running devil's advocate...")
+            challenge = challenge_proposal(proposal, llm_call=llm_call)
+            print(f"  Challenge arguments: {len(challenge.challenge_arguments)}")
+            print(f"  Concerns addressed: {challenge.concerns_addressed}")
+            if challenge.remaining_concerns:
+                print(f"  Remaining concerns: {len(challenge.remaining_concerns)}")
+
+            # If challenge concerns not addressed, skip to next iteration
+            if not challenge.concerns_addressed:
+                print("  SKIP: Challenge concerns not adequately addressed.")
+                patch_history.rejected_patches.append(
+                    {
+                        "target_file": proposal.target_file,
+                        "description": proposal.description,
+                        "rejection_reason": "Challenge concerns not addressed",
+                    }
+                )
+                iter_duration = time.time() - iter_start
+                iterations.append(
+                    IterationResult(
+                        iteration=iteration,
+                        report=report.to_dict(),
+                        category_analyses=analyses_dicts,
+                        improvements_applied=[],
+                        patch_proposal=proposal_dict,
+                        duration_seconds=iter_duration,
+                    )
+                )
+                continue
+
+            # Phase 5: VOTE - 3-reviewer voting
+            print("\n[Phase 5/8] VOTE - Running 3-reviewer voting...")
+            review = vote_on_proposal(proposal, challenge=challenge, llm_call=llm_call)
+            print(f"  Decision: {review.decision}")
+            for v in review.votes:
+                print(f"    [{v.reviewer_id}] {v.vote}: {v.rationale[:60]}...")
+
+            review_dict = review_result_to_dict(review)
+
+            if review.decision == "rejected":
+                print("  SKIP: Proposal rejected by reviewers.")
+                patch_history.rejected_patches.append(
+                    {
+                        "target_file": proposal.target_file,
+                        "description": proposal.description,
+                        "rejection_reason": review.consensus_rationale[:200],
+                    }
+                )
+                iter_duration = time.time() - iter_start
+                iterations.append(
+                    IterationResult(
+                        iteration=iteration,
+                        report=report.to_dict(),
+                        category_analyses=analyses_dicts,
+                        improvements_applied=[],
+                        patch_proposal=proposal_dict,
+                        review_result=review_dict,
+                        duration_seconds=iter_duration,
+                    )
+                )
+                continue
+
+            # Phase 6: APPLY - Apply the accepted patch
+            print("\n[Phase 6/8] APPLY - Applying accepted patch...")
+            applied_description = f"[{review.decision}] {proposal.description}"
+            patch_history.applied_patches.append(
+                {
+                    "target_file": proposal.target_file,
+                    "description": proposal.description,
+                    "hypothesis": proposal.hypothesis,
+                    "confidence": proposal.confidence,
+                }
+            )
+            print(f"  Applied: {applied_description[:80]}")
+
+            # Phase 7: RE-EVAL - Not implemented in stub mode (requires
+            # re-running the eval with the actual code change applied).
+            # In production, this would re-run the eval and compare scores.
+            print("\n[Phase 7/8] RE-EVAL - Comparing scores...")
+            post_scores: dict[str, float] | None = None
+            reverted = False
+            revert_reason = ""
+
+            # Phase 8: DECIDE - Check for regression
+            print("\n[Phase 8/8] DECIDE - Checking for regression...")
+            if post_scores is not None:
+                has_regression, worst_cat, regression_pp = detect_regression(
+                    baseline_scores, post_scores, config.regression_threshold
+                )
+                if has_regression:
+                    print(
+                        f"  REVERT: {worst_cat} regressed {regression_pp:.1f}pp "
+                        f"(threshold: {config.regression_threshold:.1f}pp)"
+                    )
+                    reverted = True
+                    revert_reason = f"{worst_cat} regressed {regression_pp:.1f}pp"
+                    patch_history.reverted_patches.append(
+                        {
+                            "target_file": proposal.target_file,
+                            "description": proposal.description,
+                            "revert_reason": revert_reason,
+                        }
+                    )
+                else:
+                    print("  KEEP: No regression detected.")
+            else:
+                print("  No re-eval performed (stub mode).")
+
+            # Save results
+            report_dict = report.to_dict()
+            with open(iter_dir / "report.json", "w") as f:
+                json.dump(report_dict, f, indent=2)
+            with open(iter_dir / "analyses.json", "w") as f:
+                json.dump(analyses_dicts, f, indent=2)
+            with open(iter_dir / "proposal.json", "w") as f:
+                json.dump(proposal_dict, f, indent=2)
+            with open(iter_dir / "review.json", "w") as f:
+                json.dump(review_dict, f, indent=2)
+
+            iter_duration = time.time() - iter_start
+
+            iterations.append(
+                IterationResult(
+                    iteration=iteration,
+                    report=report_dict,
+                    category_analyses=analyses_dicts,
+                    improvements_applied=[applied_description],
+                    patch_proposal=proposal_dict,
+                    review_result=review_dict,
+                    post_scores=post_scores,
+                    reverted=reverted,
+                    revert_reason=revert_reason,
+                    duration_seconds=iter_duration,
+                )
+            )
+
+            print(f"\n  Iteration {iteration} completed in {iter_duration:.1f}s")
+
+        finally:
+            agent.close()
+
+    # Final summary
+    total_duration = time.time() - start_time
+
+    result = RunnerResult(
+        config={
+            "num_turns": config.num_turns,
+            "num_questions": config.num_questions,
+            "max_iterations": config.max_iterations,
+            "failure_threshold": config.failure_threshold,
+            "regression_threshold": config.regression_threshold,
+            "use_multi_agent": config.use_multi_agent,
+        },
+        iterations=iterations,
+        score_progression=score_progression,
+        category_progression=category_progression,
+        total_duration_seconds=total_duration,
+    )
+
+    # Save summary
+    summary = {
+        "config": result.config,
+        "score_progression": result.score_progression,
+        "category_progression": {k: [round(v, 4) for v in vals] for k, vals in result.category_progression.items()},
+        "total_duration_seconds": round(total_duration, 2),
+        "iterations_run": len(iterations),
+        "patches_applied": len(patch_history.applied_patches),
+        "patches_reverted": len(patch_history.reverted_patches),
+        "patches_rejected": len(patch_history.rejected_patches),
+    }
+    with open(output_dir / "self_improve_summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    # Print final summary
+    print(f"\n{'=' * 70}")
+    print("LONG-HORIZON SELF-IMPROVEMENT SUMMARY")
+    print(f"{'=' * 70}")
+    print(f"Iterations run: {len(iterations)}")
+    print(f"Total duration: {total_duration:.1f}s")
+    print(f"Patches applied: {len(patch_history.applied_patches)}")
+    print(f"Patches reverted: {len(patch_history.reverted_patches)}")
+    print(f"Patches rejected: {len(patch_history.rejected_patches)}")
+
+    if score_progression:
+        print(f"\nScore progression: {' -> '.join(f'{s:.2%}' for s in score_progression)}")
+
+    print("\nCategory progression:")
+    for cat, scores in sorted(category_progression.items()):
+        scores_str = " -> ".join(f"{s:.2%}" for s in scores)
+        print(f"  {cat}: {scores_str}")
+
+    print(f"\nResults saved to: {config.output_dir}")
+
+    return result
+
+
+def main() -> None:
+    """CLI entry point for long-horizon self-improvement."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Long-horizon memory self-improvement runner")
+    parser.add_argument("--turns", type=int, default=100, help="Dialogue turns (default: 100)")
+    parser.add_argument("--questions", type=int, default=20, help="Quiz questions (default: 20)")
+    parser.add_argument("--iterations", type=int, default=3, help="Max iterations (default: 3)")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.7,
+        help="Failure threshold (default: 0.7)",
+    )
+    parser.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=5.0,
+        help="Max regression in pp before auto-revert (default: 5.0)",
+    )
+    parser.add_argument(
+        "--multi-agent",
+        action="store_true",
+        help="Use MultiAgentLearningAgent",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="/tmp/long-horizon-self-improve",
+        help="Output directory",
+    )
+    parser.add_argument("--model", default="", help="Agent model")
+    parser.add_argument("--grader-model", default="", help="Grader model")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    config = LongHorizonRunnerConfig(
+        num_turns=args.turns,
+        num_questions=args.questions,
+        seed=args.seed,
+        max_iterations=args.iterations,
+        failure_threshold=args.threshold,
+        regression_threshold=args.regression_threshold,
+        use_multi_agent=args.multi_agent,
+        output_dir=args.output_dir,
+        agent_model=args.model,
+        grader_model=args.grader_model,
+    )
+
+    result = run_long_horizon_self_improve(config)
+
+    if not result.iterations:
+        print("\nNo iterations completed.")
+        sys.exit(1)
+
+    final_score = result.score_progression[-1] if result.score_progression else 0.0
+    if final_score < 0.5:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "run_long_horizon_self_improve",
+    "LongHorizonRunnerConfig",
+    "CategoryAnalysis",
+    "RunnerResult",
+    "IterationResult",
+    "detect_regression",
+]

--- a/src/amplihack_eval/eval/metacognition_grader.py
+++ b/src/amplihack_eval/eval/metacognition_grader.py
@@ -1,0 +1,342 @@
+"""Metacognition grader with 4-dimension scoring.
+
+Evaluates student learning across four metacognitive dimensions:
+1. Factual Accuracy - Are the facts correct?
+2. Self-Awareness - Does the student know what it knows/doesn't know?
+3. Knowledge Boundaries - Can the student identify gaps?
+4. Explanation Quality - Are self-explanations coherent and insightful?
+
+Philosophy:
+- Single responsibility: Grade metacognition only
+- LLM-powered evaluation via SDK adapter
+- Structured JSON output for reliable parsing
+- Graceful degradation on errors
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+
+from amplihack_eval.llm import completion
+
+logger = logging.getLogger(__name__)
+
+DIMENSION_NAMES = [
+    "factual_accuracy",
+    "self_awareness",
+    "knowledge_boundaries",
+    "explanation_quality",
+]
+
+
+@dataclass
+class Dimension:
+    """A single scoring dimension.
+
+    Attributes:
+        name: Dimension identifier
+        score: Score from 0.0 to 1.0
+        reasoning: LLM's reasoning for the score
+    """
+
+    name: str
+    score: float
+    reasoning: str
+
+
+@dataclass
+class MetacognitionScore:
+    """Complete metacognition evaluation result.
+
+    Attributes:
+        dimensions: List of 4 dimension scores
+        overall_score: Mean of all dimension scores
+        summary: Human-readable summary
+    """
+
+    dimensions: list[Dimension]
+    overall_score: float
+    summary: str
+
+
+class MetacognitionGrader:
+    """Grades student metacognition across 4 dimensions.
+
+    Uses LLM to evaluate how well a student understands what they know
+    and what they do not know, beyond just factual correctness.
+
+    Args:
+        model: LLM model identifier
+
+    Example:
+        >>> grader = MetacognitionGrader()
+        >>> score = grader.grade(
+        ...     question="What does L1 evaluate?",
+        ...     expected_answer="L1 evaluates direct recall.",
+        ...     student_answer="L1 tests recall of facts.",
+        ...     self_explanation="I know this because recall means remembering.",
+        ... )
+        >>> print(score.overall_score)  # 0.8125
+    """
+
+    def __init__(self, model: str = "") -> None:
+        self.model = model or os.environ.get("EVAL_MODEL", "claude-opus-4-6")
+
+    async def grade(
+        self,
+        question: str,
+        expected_answer: str,
+        student_answer: str,
+        self_explanation: str,
+    ) -> MetacognitionScore:
+        """Grade a single question-answer pair on 4 metacognition dimensions.
+
+        Args:
+            question: The quiz question
+            expected_answer: Correct answer
+            student_answer: Student's answer
+            self_explanation: Student's self-explanation
+
+        Returns:
+            MetacognitionScore with 4 dimensions and overall score
+        """
+        try:
+            return await self._grade_with_llm(question, expected_answer, student_answer, self_explanation)
+        except Exception as e:
+            logger.warning("Grading failed: %s", e)
+            return self._zero_score("Grading failed due to an internal error")
+
+    async def batch_grade(self, items: list[dict[str, str]]) -> list[MetacognitionScore]:
+        """Grade multiple question-answer pairs.
+
+        Args:
+            items: List of dicts with keys:
+                question, expected, actual, explanation
+
+        Returns:
+            List of MetacognitionScore objects
+        """
+        results = []
+        for item in items:
+            score = await self.grade(
+                question=item["question"],
+                expected_answer=item["expected"],
+                student_answer=item["actual"],
+                self_explanation=item.get("explanation", ""),
+            )
+            results.append(score)
+        return results
+
+    async def _grade_with_llm(
+        self,
+        question: str,
+        expected_answer: str,
+        student_answer: str,
+        self_explanation: str,
+    ) -> MetacognitionScore:
+        """Use LLM to evaluate metacognition."""
+        prompt = f"""Evaluate the student's metacognition across 4 dimensions.
+
+Question: {question}
+Expected Answer: {expected_answer}
+Student's Answer: {student_answer}
+Student's Self-Explanation: {self_explanation or "(none provided)"}
+
+Score each dimension from 0.0 to 1.0:
+
+1. **factual_accuracy**: Are the student's stated facts correct?
+   - 1.0: All facts correct
+   - 0.5: Mix of correct and incorrect
+   - 0.0: Mostly incorrect
+
+2. **self_awareness**: Does the student accurately assess their own knowledge?
+   - 1.0: Knows what they know and what they do not know
+   - 0.5: Some awareness of knowledge gaps
+   - 0.0: Overconfident or completely unaware
+
+3. **knowledge_boundaries**: Can the student identify the limits of their knowledge?
+   - 1.0: Clearly identifies what is known vs. unknown
+   - 0.5: Vague boundaries
+   - 0.0: Cannot distinguish known from unknown
+
+4. **explanation_quality**: Are the self-explanations coherent and insightful?
+   - 1.0: Clear, logical reasoning that demonstrates understanding
+   - 0.5: Some reasoning but shallow
+   - 0.0: No meaningful explanation
+
+Return ONLY a JSON object with this structure:
+{{"factual_accuracy": {{"score": 0.9, "reasoning": "brief explanation"}},
+"self_awareness": {{"score": 0.8, "reasoning": "brief explanation"}},
+"knowledge_boundaries": {{"score": 0.7, "reasoning": "brief explanation"}},
+"explanation_quality": {{"score": 0.85, "reasoning": "brief explanation"}}}}"""
+
+        response_text = await completion(
+            [
+                {
+                    "role": "system",
+                    "content": "You are a metacognition evaluation expert. Return only valid JSON.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            model=self.model,
+            temperature=0.3,
+        )
+
+        response_text = response_text.strip()
+        return self._parse_grading_response(response_text)
+
+    def _parse_grading_response(self, response_text: str) -> MetacognitionScore:
+        """Parse LLM grading response into MetacognitionScore."""
+        try:
+            data = json.loads(response_text)
+        except json.JSONDecodeError:
+            # Try markdown code block extraction
+            if "```json" in response_text:
+                json_start = response_text.find("```json") + 7
+                json_end = response_text.find("```", json_start)
+                json_str = response_text[json_start:json_end].strip()
+                data = json.loads(json_str)
+            else:
+                raise
+
+        dimensions = []
+        for name in DIMENSION_NAMES:
+            dim_data = data.get(name, {"score": 0.0, "reasoning": "Not evaluated"})
+            score = float(dim_data.get("score", 0.0))
+            # Clamp to valid range
+            score = max(0.0, min(1.0, score))
+            dimensions.append(
+                Dimension(
+                    name=name,
+                    score=score,
+                    reasoning=dim_data.get("reasoning", ""),
+                )
+            )
+
+        overall = sum(d.score for d in dimensions) / len(dimensions) if dimensions else 0.0
+
+        return MetacognitionScore(
+            dimensions=dimensions,
+            overall_score=overall,
+            summary=self._generate_summary(dimensions, overall),
+        )
+
+    def _generate_summary(self, dimensions: list[Dimension], overall: float) -> str:
+        """Generate human-readable summary from dimension scores."""
+        if overall >= 0.8:
+            level = "strong metacognition"
+        elif overall >= 0.6:
+            level = "moderate metacognition"
+        elif overall >= 0.4:
+            level = "limited metacognition"
+        else:
+            level = "weak metacognition"
+
+        strongest = max(dimensions, key=lambda d: d.score)
+        weakest = min(dimensions, key=lambda d: d.score)
+
+        return (
+            f"Student demonstrated {level} (overall: {overall:.2f}). "
+            f"Strongest: {strongest.name} ({strongest.score:.2f}). "
+            f"Weakest: {weakest.name} ({weakest.score:.2f})."
+        )
+
+    def _zero_score(self, reason: str) -> MetacognitionScore:
+        """Return a zero score for error cases."""
+        dimensions = [Dimension(name=name, score=0.0, reasoning=reason) for name in DIMENSION_NAMES]
+        return MetacognitionScore(
+            dimensions=dimensions,
+            overall_score=0.0,
+            summary=f"Grading failed: {reason}",
+        )
+
+
+@dataclass
+class ReasoningTraceScore:
+    """Score from reasoning trace analysis (progressive test suite interface).
+
+    Maps metacognition dimensions to the trace-based naming convention:
+    - effort_calibration: How well the agent calibrated reasoning effort
+    - sufficiency_judgment: Whether the agent knew when it had enough info
+    - search_quality: Quality of memory search and retrieval
+    - self_correction: Ability to detect and correct errors
+    - overall: Mean of all dimensions
+    - details: Raw dimension data
+    """
+
+    effort_calibration: float
+    sufficiency_judgment: float
+    search_quality: float
+    self_correction: float
+    overall: float
+    details: dict
+
+
+async def grade_metacognition(
+    trace: dict | str,
+    answer_score: float,
+    level: str,
+    model: str = "",
+) -> ReasoningTraceScore:
+    """Grade metacognition from a reasoning trace (convenience function).
+
+    Bridges the progressive_test_suite interface to MetacognitionGrader.
+
+    Args:
+        trace: Reasoning trace (dict or string) from agent execution
+        answer_score: Score the answer received (0-1)
+        level: Test level (L1-L6)
+        model: LLM model for grading
+
+    Returns:
+        ReasoningTraceScore with dimension scores
+    """
+    if isinstance(trace, str):
+        trace_text = trace
+    else:
+        trace_text = json.dumps(trace)
+
+    grader = MetacognitionGrader(model=model)
+    try:
+        result = await grader.grade(
+            question=f"[{level}] Reasoning trace evaluation",
+            expected_answer=f"Score: {answer_score:.2f}",
+            student_answer=trace_text[:2000],
+            self_explanation=trace_text[:2000],
+        )
+
+        # Map 4 dimensions to trace-based naming
+        dim_map = {d.name: d.score for d in result.dimensions}
+        return ReasoningTraceScore(
+            effort_calibration=dim_map.get("self_awareness", 0.0),
+            sufficiency_judgment=dim_map.get("knowledge_boundaries", 0.0),
+            search_quality=dim_map.get("factual_accuracy", 0.0),
+            self_correction=dim_map.get("explanation_quality", 0.0),
+            overall=result.overall_score,
+            details={
+                "dimensions": {d.name: {"score": d.score, "reasoning": d.reasoning} for d in result.dimensions},
+                "summary": result.summary,
+            },
+        )
+    except Exception as e:
+        logger.warning("Metacognition grading failed: %s", e)
+        return ReasoningTraceScore(
+            effort_calibration=0.0,
+            sufficiency_judgment=0.0,
+            search_quality=0.0,
+            self_correction=0.0,
+            overall=0.0,
+            details={"error": str(e)},
+        )
+
+
+__all__ = [
+    "MetacognitionGrader",
+    "MetacognitionScore",
+    "Dimension",
+    "grade_metacognition",
+    "ReasoningTraceScore",
+]

--- a/src/amplihack_eval/eval/progressive_test_suite.py
+++ b/src/amplihack_eval/eval/progressive_test_suite.py
@@ -1,0 +1,965 @@
+"""Progressive test suite for agent learning evaluation.
+
+Runs 12 levels of increasing difficulty:
+- L1: Single source direct recall (baseline)
+- L2: Multi-source synthesis
+- L3: Temporal reasoning
+- L4: Procedural learning
+- L5: Contradiction handling
+- L6: Incremental learning
+- L7: Teacher-student knowledge transfer
+- L8: Metacognition
+- L9: Causal reasoning
+- L10: Counterfactual reasoning
+- L11: Novel skill acquisition
+- L12: Far transfer
+
+Philosophy: Comprehensive evaluation from simple to complex,
+measuring learning capability across multiple dimensions.
+"""
+
+import json
+import statistics
+import subprocess
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .grader import grade_answer
+from .metacognition_grader import grade_metacognition
+
+# Keep this in sync with pyproject.toml's direct git dependency pin.
+AMPLIHACK_AGENT_EVAL_REV = "d7a28a552bed6e8daa752e465475024b281913f6"  # pragma: allowlist secret
+AMPLIHACK_AGENT_EVAL_INSTALL = (
+    "pip install 'amplihack-agent-eval @ "
+    "git+https://github.com/rysweet/amplihack-agent-eval.git@"
+    f"{AMPLIHACK_AGENT_EVAL_REV}'"
+)
+
+try:
+    from amplihack_eval.data.progressive_levels import (  # type: ignore[import-not-found]
+        ADVANCED_LEVELS,
+        ALL_LEVELS,
+        TestLevel,
+    )
+except ImportError:
+    raise ImportError(
+        f"amplihack-agent-eval package is required but not installed. Install with: {AMPLIHACK_AGENT_EVAL_INSTALL}"
+    )
+
+# Public alias used by callers (and tests) that want a single, stable name
+# for the progressive level container. ``LEVELS`` is a dict keyed by level
+# id (``"L1"``..``"L12"``) and indexed integer (``1``..``12``) so callers
+# can look up by either form.
+LEVELS: dict = {}
+for _lvl in ALL_LEVELS + ADVANCED_LEVELS:
+    LEVELS[_lvl.level_id] = _lvl
+    try:
+        LEVELS[int(_lvl.level_id.lstrip("L"))] = _lvl
+    except (ValueError, AttributeError):
+        pass
+del _lvl
+
+# NOTE (issue #48 follow-up): the subprocess invocations below still target
+# the upstream ``amplihack.eval.agent_subprocess`` and
+# ``amplihack.eval.teaching_subprocess`` modules. Those modules depend on
+# ``amplihack.agents.domain_agents.*`` and have not yet been ported —
+# tracked as deferred follow-up work. Import-only consumers of this module
+# are unaffected; only callers that exercise the learning/testing/teaching
+# subprocess helpers require the upstream package on PATH.
+
+
+@dataclass
+class ProgressiveConfig:
+    """Configuration for progressive test suite."""
+
+    output_dir: str
+    agent_name: str
+    levels_to_run: list[str] | None = None  # None = run all
+    memory_backend: str = "amplihack-memory-lib"
+    sdk: str = "mini"  # SDK type: mini, claude, copilot, microsoft
+    grader_votes: int = 1  # Number of grading votes per question (1=single, 3=majority)
+
+
+@dataclass
+class LevelResult:
+    """Result for a single level."""
+
+    level_id: str
+    level_name: str
+    success: bool
+    scores: dict | None = None
+    error_message: str | None = None
+
+
+@dataclass
+class ProgressiveResult:
+    """Result of entire progressive test suite."""
+
+    success: bool
+    level_results: list[LevelResult]
+    overall_scores: dict | None = None
+    error_message: str | None = None
+
+
+def _extract_json_line(stdout: str) -> str:
+    """Extract the JSON object line from subprocess stdout.
+
+    Subprocess stdout may contain LLM warnings, deprecation notices,
+    or other non-JSON lines mixed in. This finds the line that is a valid
+    JSON object starting with '{'.
+
+    Args:
+        stdout: Raw subprocess stdout
+
+    Returns:
+        The JSON line, or '{}' if none found
+    """
+    # Search from last line backward (JSON output is printed last by agent_subprocess)
+    for line in reversed(stdout.strip().splitlines()):
+        stripped = line.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                json.loads(stripped)
+                return stripped
+            except json.JSONDecodeError:
+                continue
+    return "{}"
+
+
+def run_learning_subprocess(articles: list, agent_name: str, sdk: str = "mini") -> tuple[bool, str]:
+    """Run learning phase as subprocess.
+
+    Args:
+        articles: List of article dicts to learn from
+        agent_name: Agent identifier
+        sdk: SDK type to pass to agent subprocess
+
+    Returns:
+        Tuple of (success, error_message_or_data)
+    """
+    learning_input = [
+        {
+            "url": a.url,
+            "title": a.title,
+            "content": a.content,
+            "published": a.published,
+            "metadata": a.metadata or {},
+        }
+        for a in articles
+    ]
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "amplihack.eval.agent_subprocess",
+                "--phase",
+                "learning",
+                "--agent-name",
+                agent_name,
+                "--sdk",
+                sdk,
+            ],
+            input=json.dumps(learning_input),
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "Learning phase timed out after 600 seconds"
+
+    if result.returncode != 0:
+        return False, result.stderr
+
+    return True, _extract_json_line(result.stdout)
+
+
+def run_testing_subprocess(questions: list, agent_name: str, sdk: str = "mini") -> tuple[bool, str]:
+    """Run testing phase as subprocess.
+
+    Args:
+        questions: List of question dicts to answer
+        agent_name: Agent identifier
+        sdk: SDK type to pass to agent subprocess
+
+    Returns:
+        Tuple of (success, error_message_or_data)
+    """
+    testing_input = [
+        {
+            "question": q.question,
+            "expected_answer": q.expected_answer,
+            "level": q.level,
+        }
+        for q in questions
+    ]
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "amplihack.eval.agent_subprocess",
+                "--phase",
+                "testing",
+                "--agent-name",
+                agent_name,
+                "--sdk",
+                sdk,
+            ],
+            input=json.dumps(testing_input),
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "Testing phase timed out after 600 seconds"
+
+    if result.returncode != 0:
+        return False, result.stderr
+
+    return True, _extract_json_line(result.stdout)
+
+
+def _isolate_memory_for_level(agent_name: str, level_id: str) -> str:
+    """Create an isolated agent name for each level to avoid cross-level interference.
+
+    Each level gets a unique agent name which maps to a separate memory database.
+    This prevents facts from L1 leaking into L2, etc.
+
+    Args:
+        agent_name: Base agent name
+        level_id: Level identifier (L1, L2, etc.)
+
+    Returns:
+        Isolated agent name string
+    """
+    return f"{agent_name}_{level_id}_{int(time.time())}"
+
+
+def run_l7_teaching_eval(level: TestLevel, config: ProgressiveConfig, level_dir: Path) -> LevelResult:
+    """Run L7 teaching evaluation using the TeachingSession framework.
+
+    L7 is special: it uses a teacher-student multi-turn dialogue rather than
+    single-pass learning+testing. The teacher learns the articles, then teaches
+    a student agent through multiple turns. The student is then tested.
+
+    Args:
+        level: L7 test level definition
+        config: Progressive configuration
+        level_dir: Output directory for L7
+
+    Returns:
+        LevelResult with scores and status
+    """
+    level_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Phase 1: Learn articles (same as other levels)
+        agent_name = _isolate_memory_for_level(config.agent_name, "L7")
+        success, data = run_learning_subprocess(level.articles, agent_name, sdk=config.sdk)
+        if not success:
+            return LevelResult(
+                level_id=level.level_id,
+                level_name=level.level_name,
+                success=False,
+                error_message=f"L7 learning phase failed: {data}",
+            )
+
+        learning_data = json.loads(data)
+        with open(level_dir / "learning_phase.log", "w") as f:
+            json.dump(learning_data, f, indent=2)
+
+        # Phase 2: Run teaching session (teacher teaches student)
+        # Build knowledge base from the articles for the teacher
+        knowledge_base = []
+        for article in level.articles:
+            knowledge_base.append(f"Title: {article.title}")
+            knowledge_base.append(article.content)
+
+        # Run teaching session as subprocess to isolate state
+        teaching_result = _run_teaching_subprocess(knowledge_base, agent_name)
+        with open(level_dir / "teaching_session.log", "w") as f:
+            json.dump(teaching_result, f, indent=2)
+
+        # Phase 3: Test the student (same agent, already has knowledge from teaching)
+        success, data = run_testing_subprocess(level.questions, agent_name, sdk=config.sdk)
+        if not success:
+            return LevelResult(
+                level_id=level.level_id,
+                level_name=level.level_name,
+                success=False,
+                error_message=f"L7 testing phase failed: {data}",
+            )
+
+        testing_data = json.loads(data)
+        with open(level_dir / "testing_phase.log", "w") as f:
+            json.dump(testing_data, f, indent=2)
+
+        # Grade answers
+        all_grades = []
+        for i, answer_data in enumerate(testing_data["answers"]):
+            question = level.questions[i]
+
+            grade = grade_answer(
+                question=question.question,
+                expected=question.expected_answer,
+                actual=answer_data["answer"],
+                level=question.level,
+                num_votes=config.grader_votes,
+            )
+
+            all_grades.append(
+                {
+                    "question": question.question,
+                    "level": question.level,
+                    "reasoning_type": question.reasoning_type,
+                    "expected": question.expected_answer,
+                    "actual": answer_data["answer"],
+                    "score": grade.score,
+                    "reasoning": grade.reasoning,
+                    "metacognition": None,
+                }
+            )
+
+        if all_grades:
+            avg_score = sum(g["score"] for g in all_grades) / len(all_grades)
+            scores = {
+                "average": avg_score,
+                "count": len(all_grades),
+                "details": all_grades,
+                "metacognition": None,
+                "teaching_session": teaching_result,
+            }
+        else:
+            scores = {"average": 0.0, "count": 0, "details": [], "metacognition": None}
+
+        with open(level_dir / "scores.json", "w") as f:
+            json.dump(scores, f, indent=2)
+
+        return LevelResult(level_id=level.level_id, level_name=level.level_name, success=True, scores=scores)
+
+    except Exception as e:
+        return LevelResult(
+            level_id=level.level_id,
+            level_name=level.level_name,
+            success=False,
+            error_message=str(e),
+        )
+
+
+def _run_teaching_subprocess(knowledge_base: list[str], agent_name: str) -> dict:
+    """Run a teaching session in a subprocess.
+
+    The teaching session creates a teacher-student dialogue where the teacher
+    uses the knowledge base to teach the student, who then stores the knowledge
+    in memory for later testing.
+
+    Args:
+        knowledge_base: List of knowledge strings (article titles and content)
+        agent_name: Agent identifier (shared with testing phase)
+
+    Returns:
+        Dict with teaching session results
+    """
+    teaching_input = {
+        "knowledge_base": knowledge_base,
+        "agent_name": agent_name,
+        "max_turns": 4,
+    }
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "amplihack.eval.teaching_subprocess",
+                "--agent-name",
+                agent_name,
+            ],
+            input=json.dumps(teaching_input),
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "turns": 0, "error": "Teaching session timed out"}
+
+    if result.returncode != 0:
+        return {"status": "error", "turns": 0, "error": result.stderr[:500]}
+
+    try:
+        output = _extract_json_line(result.stdout)
+        return json.loads(output)
+    except (json.JSONDecodeError, Exception):
+        return {"status": "completed", "turns": 0, "raw_output": result.stdout[:500]}
+
+
+def run_single_level(level: TestLevel, config: ProgressiveConfig, level_dir: Path) -> LevelResult:
+    """Run evaluation for a single level.
+
+    Args:
+        level: Test level definition
+        config: Progressive configuration
+        level_dir: Output directory for this level
+
+    Returns:
+        LevelResult with scores and status
+    """
+    level_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use L7 teaching path for teacher-student levels
+    if level.level_id == "L7":
+        return run_l7_teaching_eval(level, config, level_dir)
+
+    # Memory isolation: each level gets a unique agent name
+    isolated_agent_name = _isolate_memory_for_level(config.agent_name, level.level_id)
+
+    try:
+        # Handle incremental learning (Level 6)
+        if level.requires_update_handling:
+            # Phase 1: Learn from initial articles
+            initial_articles = [a for a in level.articles if (a.metadata or {}).get("phase") == "initial"]
+            success, data = run_learning_subprocess(initial_articles, isolated_agent_name, sdk=config.sdk)
+            if not success:
+                return LevelResult(
+                    level_id=level.level_id,
+                    level_name=level.level_name,
+                    success=False,
+                    error_message=f"Learning phase 1 failed: {data}",
+                )
+
+            learning1_data = json.loads(data)
+            with open(level_dir / "learning_phase1.log", "w") as f:
+                json.dump(learning1_data, f, indent=2)
+
+            # Phase 2: Learn from update articles
+            update_articles = [a for a in level.articles if (a.metadata or {}).get("phase") == "update"]
+            success, data = run_learning_subprocess(update_articles, isolated_agent_name, sdk=config.sdk)
+            if not success:
+                return LevelResult(
+                    level_id=level.level_id,
+                    level_name=level.level_name,
+                    success=False,
+                    error_message=f"Learning phase 2 failed: {data}",
+                )
+
+            learning2_data = json.loads(data)
+            with open(level_dir / "learning_phase2.log", "w") as f:
+                json.dump(learning2_data, f, indent=2)
+
+        else:
+            # Standard learning: all articles at once
+            success, data = run_learning_subprocess(level.articles, isolated_agent_name, sdk=config.sdk)
+            if not success:
+                return LevelResult(
+                    level_id=level.level_id,
+                    level_name=level.level_name,
+                    success=False,
+                    error_message=f"Learning phase failed: {data}",
+                )
+
+            learning_data = json.loads(data)
+            with open(level_dir / "learning_phase.log", "w") as f:
+                json.dump(learning_data, f, indent=2)
+
+        # Testing phase
+        success, data = run_testing_subprocess(level.questions, isolated_agent_name, sdk=config.sdk)
+        if not success:
+            return LevelResult(
+                level_id=level.level_id,
+                level_name=level.level_name,
+                success=False,
+                error_message=f"Testing phase failed: {data}",
+            )
+
+        testing_data = json.loads(data)
+        with open(level_dir / "testing_phase.log", "w") as f:
+            json.dump(testing_data, f, indent=2)
+
+        # Grade answers
+        all_grades = []
+        for i, answer_data in enumerate(testing_data["answers"]):
+            question = level.questions[i]
+
+            grade = grade_answer(
+                question=question.question,
+                expected=question.expected_answer,
+                actual=answer_data["answer"],
+                level=question.level,
+                num_votes=config.grader_votes,
+            )
+
+            # Grade metacognition if trace available
+            metacog = None
+            trace = answer_data.get("reasoning_trace")
+            if trace:
+                metacog_grade = grade_metacognition(
+                    trace=trace,
+                    answer_score=grade.score,
+                    level=question.level,
+                )
+                metacog = {
+                    "effort_calibration": metacog_grade.effort_calibration,
+                    "sufficiency_judgment": metacog_grade.sufficiency_judgment,
+                    "search_quality": metacog_grade.search_quality,
+                    "self_correction": metacog_grade.self_correction,
+                    "overall": metacog_grade.overall,
+                    "details": metacog_grade.details,
+                }
+
+            all_grades.append(
+                {
+                    "question": question.question,
+                    "level": question.level,
+                    "reasoning_type": question.reasoning_type,
+                    "expected": question.expected_answer,
+                    "actual": answer_data["answer"],
+                    "score": grade.score,
+                    "reasoning": grade.reasoning,
+                    "metacognition": metacog,
+                }
+            )
+
+        # Calculate scores
+        if all_grades:
+            avg_score = sum(g["score"] for g in all_grades) / len(all_grades)
+
+            # Calculate metacognition averages if available
+            metacog_scores = [g["metacognition"] for g in all_grades if g.get("metacognition")]
+            metacog_avg = None
+            if metacog_scores:
+                metacog_avg = {
+                    "effort_calibration": sum(m["effort_calibration"] for m in metacog_scores) / len(metacog_scores),
+                    "sufficiency_judgment": sum(m["sufficiency_judgment"] for m in metacog_scores)
+                    / len(metacog_scores),
+                    "search_quality": sum(m["search_quality"] for m in metacog_scores) / len(metacog_scores),
+                    "self_correction": sum(m["self_correction"] for m in metacog_scores) / len(metacog_scores),
+                    "overall": sum(m["overall"] for m in metacog_scores) / len(metacog_scores),
+                }
+
+            scores = {
+                "average": avg_score,
+                "count": len(all_grades),
+                "details": all_grades,
+                "metacognition": metacog_avg,
+            }
+        else:
+            scores = {"average": 0.0, "count": 0, "details": [], "metacognition": None}
+
+        # Save grading results
+        with open(level_dir / "scores.json", "w") as f:
+            json.dump(scores, f, indent=2)
+
+        return LevelResult(level_id=level.level_id, level_name=level.level_name, success=True, scores=scores)
+
+    except Exception as e:
+        return LevelResult(
+            level_id=level.level_id,
+            level_name=level.level_name,
+            success=False,
+            error_message=str(e),
+        )
+
+
+def run_progressive_suite(config: ProgressiveConfig) -> ProgressiveResult:
+    """Run complete progressive test suite.
+
+    Args:
+        config: Progressive suite configuration
+
+    Returns:
+        ProgressiveResult with all level results and overall scores
+    """
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Determine which levels to run
+    from amplihack_eval.data.progressive_levels import (  # type: ignore[import-not-found]
+        NOVEL_SKILL_LEVELS,
+        TEACHER_STUDENT_LEVELS,
+        TRANSFER_LEVELS,
+    )
+
+    all_available = ALL_LEVELS + TEACHER_STUDENT_LEVELS + ADVANCED_LEVELS + NOVEL_SKILL_LEVELS + TRANSFER_LEVELS
+    if config.levels_to_run:
+        levels_to_run = [lvl for lvl in all_available if lvl.level_id in config.levels_to_run]
+    else:
+        levels_to_run = ALL_LEVELS  # Default: L1-L6 only (L8-L10 need --advanced)
+
+    # Run each level
+    level_results = []
+    for level in levels_to_run:
+        print(f"\n{'=' * 70}")
+        print(f"Running {level.level_id}: {level.level_name}")
+        print(f"{'=' * 70}")
+        print(f"Description: {level.description}")
+        print(f"Articles: {len(level.articles)}, Questions: {len(level.questions)}")
+
+        level_dir = output_dir / level.level_id
+        result = run_single_level(level, config, level_dir)
+        level_results.append(result)
+
+        if result.success and result.scores:
+            print(f"✓ {level.level_id} completed: {result.scores['average']:.2%} average score")
+        else:
+            print(f"✗ {level.level_id} failed: {result.error_message}")
+
+    # Calculate overall scores
+    successful_levels = [r for r in level_results if r.success]
+
+    if successful_levels:
+        overall_scores = {}
+
+        # Average score per level
+        for result in successful_levels:
+            overall_scores[result.level_id] = {
+                "average": result.scores["average"],
+                "count": result.scores["count"],
+            }
+
+        # Overall average across all levels
+        all_scores = [r.scores["average"] for r in successful_levels]
+        overall_scores["overall"] = sum(all_scores) / len(all_scores)
+
+        # Success rate (levels passed)
+        overall_scores["levels_passed"] = len(successful_levels)
+        overall_scores["levels_total"] = len(level_results)
+        overall_scores["pass_rate"] = len(successful_levels) / len(level_results)
+
+    else:
+        overall_scores = None
+
+    # Save summary
+    summary = {
+        "sdk": config.sdk,
+        "overall_scores": overall_scores,
+        "level_results": [
+            {
+                "level_id": r.level_id,
+                "level_name": r.level_name,
+                "success": r.success,
+                "average_score": r.scores["average"] if r.success else None,
+                "error": r.error_message if not r.success else None,
+            }
+            for r in level_results
+        ],
+    }
+
+    with open(output_dir / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    # Determine overall success
+    all_success = all(r.success for r in level_results)
+
+    return ProgressiveResult(
+        success=all_success,
+        level_results=level_results,
+        overall_scores=overall_scores,
+        error_message=None if all_success else "Some levels failed",
+    )
+
+
+@dataclass
+class ParallelResult:
+    """Result of a parallel eval run (multiple runs aggregated)."""
+
+    num_runs: int
+    median_scores: dict[str, float]
+    all_run_results: list[ProgressiveResult]
+    per_run_scores: dict[str, list[float]] = field(default_factory=dict)
+
+
+def _run_single_suite(args: tuple) -> ProgressiveResult:
+    """Run a single suite invocation (used as ProcessPoolExecutor target).
+
+    Args:
+        args: Tuple of (run_id, base_output_dir, levels_to_run, memory_backend, sdk, grader_votes)
+
+    Returns:
+        ProgressiveResult for this run
+    """
+    run_id, base_output_dir, levels_to_run, memory_backend, sdk, grader_votes = args
+    agent_name = f"agent_{run_id}_{int(time.time())}"
+    output_dir = str(Path(base_output_dir) / f"run_{run_id}")
+
+    config = ProgressiveConfig(
+        output_dir=output_dir,
+        agent_name=agent_name,
+        levels_to_run=levels_to_run,
+        memory_backend=memory_backend,
+        sdk=sdk,
+        grader_votes=grader_votes,
+    )
+
+    return run_progressive_suite(config)
+
+
+def run_parallel_suite(
+    num_runs: int,
+    base_output_dir: str,
+    levels_to_run: list[str] | None = None,
+    memory_backend: str = "amplihack-memory-lib",
+    max_workers: int = 4,
+    sdk: str = "mini",
+    grader_votes: int = 1,
+) -> ParallelResult:
+    """Run the progressive suite multiple times in parallel and report medians.
+
+    Args:
+        num_runs: Number of parallel runs
+        base_output_dir: Base output directory (each run gets a subdirectory)
+        levels_to_run: Optional list of level IDs to run
+        memory_backend: Memory backend to use
+        max_workers: Maximum concurrent processes (capped at 4)
+        sdk: SDK type to use
+        grader_votes: Number of grading votes per question
+
+    Returns:
+        ParallelResult with median scores across all runs
+    """
+    max_workers = min(max_workers, 4)  # Cap at 4 to avoid API overload
+    workers = min(max_workers, num_runs)
+
+    print(f"Starting {num_runs} parallel runs (max {workers} concurrent)...")
+
+    run_args = [(i, base_output_dir, levels_to_run, memory_backend, sdk, grader_votes) for i in range(num_runs)]
+
+    all_results: list[ProgressiveResult] = []
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_run_single_suite, args): args[0] for args in run_args}
+        for future in as_completed(futures):
+            run_id = futures[future]
+            try:
+                result = future.result()
+                all_results.append(result)
+                print(f"  Run {run_id} completed (success={result.success})")
+            except Exception as e:
+                print(f"  Run {run_id} failed with exception: {e}")
+                all_results.append(
+                    ProgressiveResult(
+                        success=False,
+                        level_results=[],
+                        overall_scores=None,
+                        error_message=str(e),
+                    )
+                )
+
+    # Collect per-level scores across all runs
+    per_run_scores: dict[str, list[float]] = {}
+    for result in all_results:
+        if not result.level_results:
+            continue
+        for lr in result.level_results:
+            if lr.success and lr.scores:
+                per_run_scores.setdefault(lr.level_id, []).append(lr.scores["average"])
+
+    # Compute median per level
+    median_scores: dict[str, float] = {}
+    for level_id, scores in sorted(per_run_scores.items()):
+        median_scores[level_id] = statistics.median(scores)
+
+    # Overall median
+    if median_scores:
+        median_scores["overall"] = statistics.median(median_scores[k] for k in median_scores)
+
+    return ParallelResult(
+        num_runs=num_runs,
+        median_scores=median_scores,
+        all_run_results=all_results,
+        per_run_scores=per_run_scores,
+    )
+
+
+def main():
+    """CLI entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Progressive Agent Learning Test Suite (Levels 1-6)")
+    parser.add_argument("--output-dir", default="./eval_progressive", help="Output directory for results")
+    parser.add_argument("--agent-name", default="progressive-test-agent", help="Agent name for memory isolation")
+    parser.add_argument(
+        "--levels",
+        nargs="+",
+        choices=["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10", "L11", "L12"],
+        help="Specific levels to run (default: L1-L6, use --advanced for L8-L12)",
+    )
+    parser.add_argument(
+        "--advanced",
+        action="store_true",
+        help="Include advanced levels (L8-L10: metacognition, causal, counterfactual)",
+    )
+    parser.add_argument("--memory-backend", default="amplihack-memory-lib", help="Memory backend to use")
+    parser.add_argument(
+        "--parallel",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Run suite N times in parallel and report median scores (max 4 concurrent)",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Alias for --parallel. Run suite N times and report median scores. "
+        "Recommended: --runs 3 for stable results on high-variance levels (L2, L5, L9, L10, L11).",
+    )
+    parser.add_argument(
+        "--sdk",
+        default="mini",
+        choices=["mini", "claude", "copilot", "microsoft"],
+        help="SDK type to evaluate (default: mini). All SDKs use the same LearningAgent "
+        "for learning/answering but validate SDK agent creation.",
+    )
+    parser.add_argument(
+        "--grader-votes",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Number of grading votes per question (default: 1). "
+        "Use 3 for majority-vote grading to reduce noise on ambiguous answers.",
+    )
+
+    args = parser.parse_args()
+
+    # --runs is an alias for --parallel; prefer --runs if both given
+    if args.runs > 0:
+        args.parallel = args.runs
+
+    # If --advanced is set, include L8-L10 in levels to run
+    if args.advanced and not args.levels:
+        args.levels = ["L1", "L2", "L3", "L4", "L5", "L6", "L8", "L9", "L10"]
+    elif args.advanced and args.levels:
+        # Add advanced levels to explicit selection
+        for lvl in ["L8", "L9", "L10"]:
+            if lvl not in args.levels:
+                args.levels.append(lvl)
+
+    # Parallel mode
+    if args.parallel > 0:
+        print("=" * 70)
+        print("PROGRESSIVE AGENT LEARNING TEST SUITE - PARALLEL MODE")
+        print("=" * 70)
+        print(f"Number of runs: {args.parallel}")
+        print(f"Output directory: {args.output_dir}")
+        if args.levels:
+            print(f"Levels to run: {', '.join(args.levels)}")
+        else:
+            print("Levels to run: All (L1-L6)")
+        print("=" * 70)
+
+        par_result = run_parallel_suite(
+            num_runs=args.parallel,
+            base_output_dir=args.output_dir,
+            levels_to_run=args.levels,
+            memory_backend=args.memory_backend,
+            sdk=args.sdk,
+            grader_votes=args.grader_votes,
+        )
+
+        # Print parallel summary
+        print("\n" + "=" * 70)
+        print("PARALLEL TEST SUITE SUMMARY")
+        print("=" * 70)
+        print(f"Completed {par_result.num_runs} runs\n")
+
+        print("Median Scores by Level:")
+        for level_id in sorted(k for k in par_result.median_scores if k != "overall"):
+            scores = par_result.per_run_scores.get(level_id, [])
+            median = par_result.median_scores[level_id]
+            scores_str = ", ".join(f"{s:.2%}" for s in scores)
+            print(f"  {level_id}: {median:.2%}  (runs: {scores_str})")
+
+        if "overall" in par_result.median_scores:
+            print(f"\nOverall Median: {par_result.median_scores['overall']:.2%}")
+
+        print(f"\nDetailed results saved to: {args.output_dir}")
+
+        # Save parallel summary
+        summary_path = Path(args.output_dir) / "parallel_summary.json"
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(summary_path, "w") as f:
+            json.dump(
+                {
+                    "num_runs": par_result.num_runs,
+                    "median_scores": par_result.median_scores,
+                    "per_run_scores": {k: [round(s, 4) for s in v] for k, v in par_result.per_run_scores.items()},
+                },
+                f,
+                indent=2,
+            )
+
+        return
+
+    # Single run mode
+    config = ProgressiveConfig(
+        output_dir=args.output_dir,
+        agent_name=args.agent_name,
+        levels_to_run=args.levels,
+        memory_backend=args.memory_backend,
+        sdk=args.sdk,
+        grader_votes=args.grader_votes,
+    )
+
+    print("=" * 70)
+    print("PROGRESSIVE AGENT LEARNING TEST SUITE")
+    print("=" * 70)
+    print(f"Output directory: {config.output_dir}")
+    print(f"Agent name: {config.agent_name}")
+    print(f"SDK: {config.sdk}")
+    if config.levels_to_run:
+        print(f"Levels to run: {', '.join(config.levels_to_run)}")
+    else:
+        print("Levels to run: All (L1-L6)")
+    print("=" * 70)
+
+    result = run_progressive_suite(config)
+
+    # Print summary
+    print("\n" + "=" * 70)
+    print("PROGRESSIVE TEST SUITE SUMMARY")
+    print("=" * 70)
+
+    if result.success:
+        print("\n✓ All levels completed successfully\n")
+    else:
+        print(f"\n✗ Some levels failed: {result.error_message}\n")
+
+    if result.overall_scores:
+        print("Scores by Level:")
+        for level_result in result.level_results:
+            if level_result.success and level_result.scores:
+                score = level_result.scores["average"]
+                count = level_result.scores["count"]
+                print(f"  {level_result.level_id} ({level_result.level_name}): {score:.2%} ({count} questions)")
+            else:
+                print(f"  {level_result.level_id} ({level_result.level_name}): FAILED")
+
+        print(f"\nOverall Average: {result.overall_scores['overall']:.2%}")
+        print(f"Levels Passed: {result.overall_scores['levels_passed']}/{result.overall_scores['levels_total']}")
+        print(f"Pass Rate: {result.overall_scores['pass_rate']:.2%}")
+
+    print(f"\nDetailed results saved to: {config.output_dir}")
+
+    if not result.success:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "run_progressive_suite",
+    "run_parallel_suite",
+    "run_single_level",
+    "ProgressiveConfig",
+    "ProgressiveResult",
+    "ParallelResult",
+    "LevelResult",
+]

--- a/src/amplihack_eval/llm.py
+++ b/src/amplihack_eval/llm.py
@@ -1,0 +1,49 @@
+"""Lazy shim re-exporting :func:`amplihack.llm.completion`.
+
+Issue #48 ports several modules out of the upstream ``amplihack`` package
+into this repository. Some of those modules call ``amplihack.llm.completion``
+to grade answers via an LLM. We do **not** want to take a hard runtime
+dependency on the ``amplihack`` package at import time — many of this
+repo's consumers (CI smoke tests, library imports, recipe wiring) never
+actually invoke a grading call.
+
+This module exposes a single name, :func:`completion`, which behaves as a
+lazy proxy:
+
+* Importing ``amplihack_eval.llm`` always succeeds, even when the
+  ``amplihack`` package is not installed.
+* The first call to ``completion(...)`` resolves
+  ``amplihack.llm.completion`` and forwards arguments to it.
+* If ``amplihack.llm`` cannot be imported, a clear :class:`ImportError`
+  is raised at *call* time (not import time) telling the user how to
+  install the missing dependency.
+
+This keeps the eval modules' public API stable while letting test
+environments without ``amplihack`` installed still import them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["completion"]
+
+_INSTALL_HINT = (
+    "amplihack_eval.llm.completion requires the upstream `amplihack` "
+    "package providing `amplihack.llm.completion`. Install it with: "
+    "pip install amplihack"
+)
+
+
+async def completion(*args: Any, **kwargs: Any) -> Any:
+    """Forward to ``amplihack.llm.completion``.
+
+    Resolved lazily so that importing this module never imports
+    ``amplihack``. Raises :class:`ImportError` with an actionable install
+    hint if the upstream package is not available at call time.
+    """
+    try:
+        from amplihack.llm import completion as _real_completion
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return await _real_completion(*args, **kwargs)

--- a/tests/test_ported_eval_modules.py
+++ b/tests/test_ported_eval_modules.py
@@ -1,0 +1,271 @@
+"""TDD tests for modules ported from amplihack.eval (issue #48).
+
+These tests are written FIRST and will fail until the corresponding modules
+are ported into ``src/amplihack_eval/`` per the design spec.
+
+Scope of this test module:
+  * Import-smoke tests for the 7 newly created modules / shim
+  * A few pure-function unit tests (grader JSON parsing, progressive level
+    lookup) chosen because they exercise behavior that does NOT require an
+    LLM, network access, or the upstream ``amplihack`` package installed.
+
+Out of scope (explicitly NOT tested here):
+  * Live LLM calls (no API keys in CI)
+  * Subprocess driving of unported ``progressive`` runner targets
+  * domain_agents / teaching_* / run_domain_evals (deferred follow-up)
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module identifiers under test (mirror design spec "new_files")
+# ---------------------------------------------------------------------------
+
+SHIM_MODULE = "amplihack_eval.llm"
+EVAL_PKG = "amplihack_eval.eval"
+
+EVAL_MODULES = [
+    "amplihack_eval.eval",
+    "amplihack_eval.eval.llm_grader",
+    "amplihack_eval.eval.grader",
+    "amplihack_eval.eval.metacognition_grader",
+    "amplihack_eval.eval.progressive_test_suite",
+    "amplihack_eval.eval.long_horizon_memory",
+    "amplihack_eval.eval.long_horizon_self_improve",
+]
+
+
+# ---------------------------------------------------------------------------
+# Phase A — Shim module
+# ---------------------------------------------------------------------------
+
+
+class TestLLMShim:
+    """The shim must import cheaply without requiring ``amplihack`` installed.
+
+    It re-exports ``completion`` lazily — i.e. importing the shim must not
+    itself import ``amplihack.llm``. ImportError surfaces only on call.
+    """
+
+    def test_shim_module_imports(self):
+        mod = importlib.import_module(SHIM_MODULE)
+        assert isinstance(mod, ModuleType)
+
+    def test_shim_exposes_completion_attribute(self):
+        mod = importlib.import_module(SHIM_MODULE)
+        assert hasattr(mod, "completion"), "amplihack_eval.llm must expose a `completion` callable (lazy shim)"
+        assert callable(mod.completion)
+
+    def test_shim_import_does_not_eagerly_load_amplihack(self, monkeypatch):
+        """Importing the shim must succeed even if `amplihack.llm` is missing.
+
+        We simulate amplihack-not-installed by blocking the import in
+        sys.modules and asserting the shim still imports.
+        """
+        import sys
+
+        # Drop any cached shim so re-import is exercised
+        sys.modules.pop(SHIM_MODULE, None)
+
+        # Make `amplihack.llm` import fail on demand
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "amplihack.llm" or name.startswith("amplihack.llm."):
+                raise ImportError("simulated: amplihack not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+
+        # The shim itself must still import (lazy)
+        importlib.import_module(SHIM_MODULE)
+
+
+# ---------------------------------------------------------------------------
+# Phase B — Eval subpackage import smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("modname", EVAL_MODULES)
+def test_eval_module_imports(modname: str):
+    """Each ported module must import cleanly with no side effects beyond
+    package init. Failure here indicates a missing port or broken rewrite
+    of an upstream ``amplihack.*`` import path.
+    """
+    mod = importlib.import_module(modname)
+    assert isinstance(mod, ModuleType)
+    assert mod.__name__ == modname
+
+
+# ---------------------------------------------------------------------------
+# Phase B2 — grader.py pure-function behavior
+# ---------------------------------------------------------------------------
+
+
+class TestPortedGrader:
+    """The ported eval.grader exposes a Grader class and grade_response helper
+    (verbatim port from upstream). Distinct from amplihack_eval.core.grader.
+    """
+
+    def test_grader_class_exists(self):
+        mod = importlib.import_module("amplihack_eval.eval.grader")
+        assert hasattr(mod, "Grader"), "ported grader must expose `Grader`"
+
+    def test_grade_response_is_callable(self):
+        mod = importlib.import_module("amplihack_eval.eval.grader")
+        # Upstream public API names — at least one must exist
+        assert any(hasattr(mod, name) for name in ("grade_response", "grade", "grade_answer")), (
+            "ported grader must expose a grading callable"
+        )
+
+    def test_does_not_collide_with_core_grader(self):
+        """Both modules coexist; they must be distinct objects."""
+        eval_grader = importlib.import_module("amplihack_eval.eval.grader")
+        core_grader = importlib.import_module("amplihack_eval.core.grader")
+        assert eval_grader is not core_grader
+        assert eval_grader.__name__ != core_grader.__name__
+
+
+# ---------------------------------------------------------------------------
+# Phase B4 — progressive_test_suite level lookup
+# ---------------------------------------------------------------------------
+
+
+class TestProgressiveTestSuite:
+    """Pure-function checks: the suite defines L1..L12 levels (per the
+    progressive eval design) and exposes a way to look one up by name/index.
+    """
+
+    def test_module_defines_levels(self):
+        mod = importlib.import_module("amplihack_eval.eval.progressive_test_suite")
+        # At least one of these level-container symbols must exist
+        candidates = ("LEVELS", "PROGRESSIVE_LEVELS", "TEST_LEVELS", "Levels")
+        found = [name for name in candidates if hasattr(mod, name)]
+        assert found, f"progressive_test_suite must expose level definitions; checked {candidates}"
+
+    def test_at_least_one_level_lookup_works(self):
+        """L1 (or index 0) must be retrievable by some public means."""
+        mod = importlib.import_module("amplihack_eval.eval.progressive_test_suite")
+        for name in ("LEVELS", "PROGRESSIVE_LEVELS", "TEST_LEVELS"):
+            container = getattr(mod, name, None)
+            if container is None:
+                continue
+            # Container is dict-like or list-like
+            try:
+                if isinstance(container, dict):
+                    assert "L1" in container or 1 in container or len(container) >= 1
+                else:
+                    assert len(container) >= 1
+                return
+            except Exception:  # pragma: no cover - defensive
+                continue
+        pytest.fail("No usable level container found for L1 lookup")
+
+
+# ---------------------------------------------------------------------------
+# Phase B5 — long_horizon_memory CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestLongHorizonMemory:
+    def test_has_cli_entrypoint(self):
+        mod = importlib.import_module("amplihack_eval.eval.long_horizon_memory")
+        assert hasattr(mod, "main") or hasattr(mod, "cli") or hasattr(mod, "run"), (
+            "long_horizon_memory must expose a CLI/main entrypoint"
+        )
+
+    def test_self_subprocess_module_string_is_rewritten(self):
+        """The upstream module self-launches via `python -m
+        amplihack.eval.long_horizon_memory`. After porting, any such literal
+        must reference the new module path so the subprocess actually finds
+        the ported code.
+        """
+        import inspect
+
+        mod = importlib.import_module("amplihack_eval.eval.long_horizon_memory")
+        try:
+            src = inspect.getsource(mod)
+        except OSError:
+            pytest.skip("source not available")
+        assert "amplihack.eval.long_horizon_memory" not in src, (
+            "stale upstream module path found in self-subprocess invocation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase B6 — long_horizon_self_improve uses local self_improve.*
+# ---------------------------------------------------------------------------
+
+
+class TestLongHorizonSelfImprove:
+    def test_has_cli_entrypoint(self):
+        mod = importlib.import_module("amplihack_eval.eval.long_horizon_self_improve")
+        assert hasattr(mod, "main") or hasattr(mod, "cli") or hasattr(mod, "run")
+
+    def test_imports_local_self_improve_package(self):
+        """Must depend on the in-repo amplihack_eval.self_improve.* modules,
+        not the upstream amplihack.self_improve.* paths.
+        """
+        import inspect
+
+        mod = importlib.import_module("amplihack_eval.eval.long_horizon_self_improve")
+        try:
+            src = inspect.getsource(mod)
+        except OSError:
+            pytest.skip("source not available")
+        assert "amplihack.self_improve" not in src, (
+            "upstream amplihack.self_improve.* import must be rewritten to amplihack_eval.self_improve.*"
+        )
+
+    def test_supports_multi_agent_flag(self):
+        """The CLI advertises a --multi-agent flag (per issue #48 description)."""
+        import inspect
+
+        mod = importlib.import_module("amplihack_eval.eval.long_horizon_self_improve")
+        try:
+            src = inspect.getsource(mod)
+        except OSError:
+            pytest.skip("source not available")
+        assert "--multi-agent" in src or "multi_agent" in src
+
+
+# ---------------------------------------------------------------------------
+# Recipe YAML reference checks
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeImportsRewritten:
+    """The two recipe YAMLs must reference the ported module paths
+    (``amplihack_eval.eval.*``) for the four self-contained modules. The
+    deferred modules (teaching_*, run_domain_evals) may still appear with
+    their upstream paths — those are out of scope.
+    """
+
+    PORTED_LEAF_NAMES = (
+        "progressive_test_suite",
+        "long_horizon_memory",
+        "long_horizon_self_improve",
+    )
+
+    @pytest.mark.parametrize(
+        "recipe_path",
+        [
+            "recipes/long-horizon-memory-eval.yaml",
+            "recipes/domain-agent-eval.yaml",
+        ],
+    )
+    def test_no_stale_amplihack_eval_refs_for_ported_modules(self, recipe_path):
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        text = (repo_root / recipe_path).read_text(encoding="utf-8")
+        for leaf in self.PORTED_LEAF_NAMES:
+            stale = f"amplihack.eval.{leaf}"
+            assert stale not in text, (
+                f"{recipe_path} still references upstream `{stale}`; must be rewritten to `amplihack_eval.eval.{leaf}`"
+            )


### PR DESCRIPTION
## Summary

Closes part of #48 — ports six self-contained eval modules from upstream
`amplihack.eval.*` into this repo's `amplihack_eval.eval.*` namespace,
adds a lazy LLM-completion shim, and updates the affected recipe so it
imports from the in-repo modules.

## Modules ported

| Upstream                                | Local                                          |
| --------------------------------------- | ---------------------------------------------- |
| `amplihack.eval.progressive_test_suite` | `amplihack_eval.eval.progressive_test_suite`   |
| `amplihack.eval.long_horizon_memory`    | `amplihack_eval.eval.long_horizon_memory`      |
| `amplihack.eval.long_horizon_self_improve` | `amplihack_eval.eval.long_horizon_self_improve` |
| `amplihack.eval.grader`                 | `amplihack_eval.eval.grader` (+ `Grader` wrapper) |
| `amplihack.eval.llm_grader`             | `amplihack_eval.eval.llm_grader`               |
| `amplihack.eval.metacognition_grader`   | `amplihack_eval.eval.metacognition_grader`     |
| `amplihack.llm.completion`              | `amplihack_eval.llm.completion` (lazy shim)    |

The shim makes the eval modules import cleanly even when the upstream
`amplihack` package is not installed; `ImportError` surfaces only when
`completion(...)` is actually called, with an actionable install hint.

## Recipe updates

- `recipes/long-horizon-memory-eval.yaml`: rewrite
  `amplihack.eval.{progressive_test_suite,long_horizon_memory,long_horizon_self_improve}`
  → `amplihack_eval.eval.*`.
- Self-subprocess module strings in `long_horizon_memory.py` rewritten to
  point at `amplihack_eval.eval.long_horizon_memory` (so `python -m`
  re-entry actually finds the ported code).
- `long_horizon_self_improve.py` rewired to in-repo
  `amplihack_eval.self_improve.{patch_proposer,reviewer_voting}`.

`recipes/domain-agent-eval.yaml` references only deferred upstream
modules (`teaching_*`, `run_domain_evals`); no changes required.

## Pre-existing bug fix (blocker)

PR #46 (`security: remove trivy from eval scenarios`) left
`src/amplihack_eval/data/hive_mind_scenarios.py` in a broken state:

- `hive_infra_q10` lost its `expected_keywords` list entirely, raising
  `TypeError` at import time and **breaking every test in the repo**.
- `_INFRA_SECURITY_FACTS` dropped to 19 entries, violating the
  `len == 20` invariant asserted in `test_hive_mind_eval.py`.

This PR restores non-Trivy keywords (`Falco`, `Cosign`, `containerd`)
on the question and adds a benign replacement security fact. Without
this fix, no porting work could be verified.

## Tests

`tests/test_ported_eval_modules.py` — 22 new tests:

- LLM shim contract (callable, lazy, ImportError-on-call)
- Import-smoke for every ported module
- Grader disambiguation vs `amplihack_eval.core.grader`
- Progressive level container + L1 lookup
- `long_horizon_memory` CLI entrypoint + no stale self-subprocess literal
- `long_horizon_self_improve` CLI + uses local `self_improve.*` + has `--multi-agent`
- Recipe YAML rewrite assertions for both recipes

**Local results:**

```
$ python -m pytest tests/ -q
479 passed, 1 skipped in 6.23s

$ ruff check .
All checks passed!

$ ruff format --check .
73 files already formatted
```

## Out of scope (deferred to follow-up)

A follow-up issue will be filed for:

- `teaching_session.py`, `teaching_eval.py`, `run_domain_evals.py`,
  `domain_eval_harness.py` — depend on `amplihack.agents.domain_agents.*`
- `agent_subprocess.py` / `teaching_subprocess.py` — invoked by
  `progressive_test_suite` via subprocess; require `domain_agents` at
  runtime
- Lazy `amplihack.agents.goal_seeking.{runtime_factory,learning_agent,sub_agents}`
  imports inside the ported modules — exercised only when an eval is
  actually run; import-only smoke tests are unaffected

See `docs/ported-modules.md` for the full status table and contracts.

## Merge readiness

- ✅ All 479 tests pass locally
- ✅ `ruff check` + `ruff format --check` clean
- ✅ Pre-existing `hive_mind_scenarios.py` blocker fixed
- ✅ Conventional commit + Co-authored-by trailer
- ⏳ CI must pass before squash-merge (no `--admin`)
